### PR TITLE
fix: resolve black canvas + asset loading issues

### DIFF
--- a/found3/rn/src/components/GameWebView.tsx
+++ b/found3/rn/src/components/GameWebView.tsx
@@ -4,7 +4,7 @@ import { WebView } from 'react-native-webview';
 import { BridgeHost } from '../utils/bridge';
 import type { StageCompleteData } from '../utils/bridge';
 
-const DEV_HOST = 'http://172.30.1.63:5173/games/found3/v1';
+const DEV_HOST = 'http://192.168.1.121:5173/games/found3/v1';
 
 interface GameWebViewProps {
   stageId: number;

--- a/lib/found3/src/game.ts
+++ b/lib/found3/src/game.ts
@@ -27,19 +27,17 @@ export function createGame(
   const startStage = config?.stage ?? 1;
   const dpr = Math.min(window.devicePixelRatio || 1, 3);
 
-  // Use parent dimensions for exact fit (no letterboxing)
-  const parentW = parent.clientWidth || DEFAULT_WIDTH;
-  const parentH = parent.clientHeight || DEFAULT_HEIGHT;
-
   const game = new Phaser.Game({
     type: Phaser.AUTO,
     parent,
-    width: parentW * dpr,
-    height: parentH * dpr,
+    width: DEFAULT_WIDTH * dpr,
+    height: DEFAULT_HEIGHT * dpr,
     backgroundColor: '#f0f2f5',
     scale: {
-      mode: Phaser.Scale.RESIZE,
-      autoCenter: Phaser.Scale.NO_CENTER,
+      mode: Phaser.Scale.FIT,
+      autoCenter: Phaser.Scale.CENTER_BOTH,
+      width: DEFAULT_WIDTH * dpr,
+      height: DEFAULT_HEIGHT * dpr,
     },
     render: {
       pixelArt: true,

--- a/lib/found3/src/scenes/PlayScene.ts
+++ b/lib/found3/src/scenes/PlayScene.ts
@@ -75,11 +75,13 @@ export class PlayScene extends Phaser.Scene {
   }
 
   preload(): void {
+    // Use absolute path to avoid issues with nested routes like /stage/:id
+    const base = '/games/found3/v1/';
     for (const key of TILE_IMAGES) {
-      this.load.image(key, `assets/tiles/${key}.png`);
+      this.load.image(key, `${base}assets/tiles/${key}.png`);
     }
-    this.load.audio('bgm1', 'assets/audio/Spring_Loaded_Scoundrel.mp3');
-    this.load.audio('bgm2', 'assets/audio/Spring_Loaded_Waltz.mp3');
+    this.load.audio('bgm1', `${base}assets/audio/Spring_Loaded_Scoundrel.mp3`);
+    this.load.audio('bgm2', `${base}assets/audio/Spring_Loaded_Waltz.mp3`);
   }
 
   create(): void {


### PR DESCRIPTION
## Summary
- **game.ts**: `Scale.RESIZE` → `Scale.FIT` 롤백 (RESIZE가 컨테이너 높이 0일 때 검정 화면 유발)
- **PlayScene.ts**: 에셋 경로를 상대 → 절대(`/games/found3/v1/assets/...`)로 변경 (nested route `/stage/:stageId`에서 에셋 로드 실패 수정)
- **GameWebView.tsx**: 네트워크 변경에 따른 DEV_HOST IP 업데이트

## Test plan
- [ ] 웹 브라우저에서 `/games/found3/v1/stage/1` 접근 시 게임 정상 표시
- [ ] 타일 이미지 + BGM 정상 로드
- [ ] Expo Go에서 WebView 게임 정상 로드

🤖 Generated with [Claude Code](https://claude.com/claude-code)