### PR TITLE
docs: rewrite README for current monorepo structure (#238)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,120 +1,196 @@
 # Mobile Arcade
 
-모바일 미니게임 모노레포. 게임 코어는 `lib/*`, 웹 서빙은 `web/arcade`, 모바일 앱 셸은 `rn`이 담당합니다.
+모바일 미니게임 모노레포. 현재 실행 구조는 `lib/{game}` → `web/arcade` → `rn` 파이프라인 한 줄로 통합되어 있습니다.
 
 ## Architecture
 
 ```
 mobile-arcade/
 ├── lib/{game}/       # 게임 코어 로직 (Phaser scenes, shared types)
-├── web/arcade/       # 통합 웹 앱 (React Router로 여러 게임 서빙)
-├── web/found3/       # found3 전용 웹 앱 (Legacy)
-├── web/crunch3/      # crunch3 전용 웹 앱 (Legacy)
-├── rn/               # 단일 Arcade RN 앱 (WebView launcher)
+├── web/arcade/       # 통합 웹 앱 (React Router로 모든 게임 서빙)
+├── rn/               # Arcade 슈퍼앱 (WebView launcher, 단일 네이티브 앱)
 ├── prd/              # 게임 기획서
-└── knowledge/        # 아키텍처/결정/진행 기록
+├── knowledge/        # 아키텍처/결정/진행 기록
+└── scripts/          # workspace 실행 헬퍼
 ```
 
-### Current Flow
+### Pipeline
 
 ```
 lib/{game}  →  web/arcade  →  rn
-(core)        (unified web)   (native shell)
+(Phaser core)  (Unified Web)  (RN WebView Shell)
 ```
 
-1. `lib/{game}`: Phaser 기반 게임 로직, 씬, 타입 정의
-2. `web/arcade`: 각 `lib` 패키지를 조합해 웹 게임 라우트를 제공
-3. `rn`: `web/arcade`의 게임 경로를 WebView로 로드하는 단일 네이티브 앱
+의존성 방향: `lib` ← `web` ← `rn`.
 
-`web/found3`, `web/crunch3`, `found3/rn`은 남아 있지만 현재 기준 구조의 중심은 아닙니다.
+1. `lib/{game}`: Phaser.io 기반 게임 로직, 씬, 타입 정의
+2. `web/arcade`: 각 `lib` 패키지를 조합해 `/games/{game}/v1` 형태의 라우트로 서빙
+3. `rn`: `web/arcade`의 게임 경로를 WebView로 로드하는 단일 슈퍼앱
+
+### Legacy Packages (Deprecated)
+
+`web/found3`, `web/crunch3`, `found3/rn`은 초기 전용 패키지로 남아 있으나 **deprecated** 상태입니다.
+신규 게임은 반드시 위의 canonical pipeline(`lib/{game}` → `web/arcade` → `rn`)을 따르세요.
 
 ## Games
 
-| Game | Description | Status |
-|------|-------------|--------|
-| found3 | 3개씩 같은 그림 퍼즐을 찾아 없애서 모든 타일을 클리어하는 게임 | 🚧 In Progress |
+현재 `rn/src/data/games.ts`에 등록된 게임 카탈로그입니다. (단일 기준 — 새 게임 추가 시 여기에 등록)
+
+| ID | Name | Category | Stages | New |
+|----|------|----------|--------|-----|
+| found3 | Found 3 | puzzle | 5 | ✓ |
+| found3-react | Found 3 (React) | puzzle | 5 | ✓ |
+| crunch3 | Crunch 3 | puzzle | 5 | ✓ |
+| blockrush | Block Rush | puzzle | — | ✓ |
+| watersort | Water Sort | puzzle | 5 | ✓ |
+| tictactoe | Tic Tac Toe | casual | — | ✓ |
+| minesweeper | Minesweeper | puzzle | — | ✓ |
+| number10 | Make 10 | puzzle | — | ✓ |
+| sudoku | Sudoku | puzzle | 5 | ✓ |
+| blockpuzzle | Block Puzzle | puzzle | — | ✓ |
+| blockcrush | Block Crush | puzzle | — | ✓ |
+| woodoku | Woodoku Blast | puzzle | — | ✓ |
+| getcolor | Get Color | puzzle | 10 | ✓ |
+| chess | Chess | strategy | — | ✓ |
+| nonogram | Nonogram | puzzle | 5 | ✓ |
+| hexaaway | Hexa Away | puzzle | 5 | ✓ |
+
+> 표는 `rn/src/data/games.ts`의 `GAMES` 배열에서 발췌합니다. 해당 파일이 단일 진실 공급원(SSoT)이며, 필드 정의(`GameInfo`) 및 카테고리 목록도 같은 파일에서 관리됩니다.
+
+## Getting Started
+
+실제 개발 흐름입니다. 두 개의 프로세스(웹 dev 서버 + Expo)를 동시에 띄우면 됩니다.
+
+```bash
+# 1) 의존성 설치 (루트에서 1회)
+pnpm install
+
+# 2) 통합 웹 앱 dev 서버 기동 (Vite)
+cd web/arcade && pnpm dev
+# → http://localhost:5173 등에서 /games/{id}/v1 경로로 각 게임 접근 가능
+
+# 3) 별도 터미널에서 RN 슈퍼앱 기동 (Expo)
+cd rn && npx expo start
+# → iOS simulator / Android emulator / 실기기(Expo Go 또는 dev build)
+```
+
+웹 게임만 확인하려면 2번까지만 실행하면 됩니다. 네이티브 WebView 경로 검증이 필요할 때 3번을 추가합니다.
+
+## RN WebView Dev Host
+
+RN 앱은 WebView로 Vite dev server에 접속합니다. 에뮬레이터/시뮬레이터는 자동 기본값이 적용되며, 실기기 연결 시에만 환경 변수 설정이 필요합니다.
+
+| 환경 | 사용 호스트 | 추가 설정 |
+|------|-------------|-----------|
+| Android emulator | `10.0.2.2` | 없음 (자동) |
+| iOS simulator | `localhost` | 없음 (자동) |
+| 실기기 (WiFi) | 로컬 IP / Bonjour | `rn/.env` 필요 |
+
+**실기기 연결 시:**
+
+```bash
+# rn/.env.example 참고
+echo "EXPO_PUBLIC_DEV_HOST=192.168.1.100" > rn/.env
+```
+
+URL 해석 규칙, 프로덕션 호스트, 브릿지 프로토콜 등 자세한 내용은 `rn/CLAUDE.md`의 "Dev URL 해상도" 및 "Message Bridge" 섹션을 참고하세요.
+
+## Development Commands
+
+루트에서 실행하는 표준 명령입니다. CI(`.github/workflows/ci.yml`)도 동일한 명령을 사용합니다.
+
+```bash
+# 모든 워크스페이스 패키지 빌드 (build 스크립트가 있는 경우만)
+pnpm build
+
+# 타입체크 (emit 없이)
+pnpm typecheck
+
+# ESLint 전체 실행
+pnpm lint
+
+# Vitest 전체 실행
+pnpm test
+```
+
+`lint` / `test`는 `scripts/run-workspace-script.cjs`를 통해 스크립트가 정의된 패키지만 순회합니다 (ADR 참고).
+
+### 특정 패키지만 실행
+
+pnpm 필터를 활용해 단일 워크스페이스만 대상으로 할 수 있습니다.
+
+```bash
+# web/arcade만 타입체크
+pnpm -r --filter @arcade/web typecheck
+
+# lib/found3만 테스트
+pnpm -r --filter @arcade/lib-found3 test
+```
+
+패키지 이름은 각 워크스페이스의 `package.json` `name` 필드를 참고하세요.
+
+## Adding a New Game
+
+새 게임 `{name}` 추가 시 canonical pipeline을 따릅니다. **햅틱은 필수** — 없는 게임은 미완성으로 간주합니다.
+
+1. **PRD** — `prd/{name}.md` 기획서 작성
+2. **Game Core** — `lib/{name}/` 패키지 생성, Phaser 씬 / 타입 / 이벤트 emit 구현
+   - 유저 입력 시점에 `this.game.events.emit('event-name')` 발행 (딜레이 금지)
+3. **Web** — `web/arcade/src/games/{name}/` 하위에 라우트 + 훅 + 컴포넌트 추가
+   - `routes.tsx`에서 `registerRoutes()`로 `/games/{name}/v1` 경로 등록
+   - `useGame` 훅에서 lib 이벤트를 받아 `bridge.haptic('event-name')` 호출
+4. **RN Catalog** — `rn/src/data/games.ts`의 `GAMES` 배열에 `GameInfo` 추가
+   - `id`, `name`, `category`, `webPath`, `icon`, `color` 등
+5. **Haptic Patterns** — `rn/src/utils/bridge.ts`의 `HAPTIC_PATTERNS` 맵에 이벤트별 `{ style, count }` 추가
+6. **pnpm workspace** — `lib/*`, `web/*`는 루트 `pnpm-workspace.yaml`의 glob에 이미 포함되므로 별도 등록 불필요. 비표준 위치에 패키지를 추가한 경우에만 `pnpm-workspace.yaml` 편집
+
+햅틱 아키텍처(ADR-014) 요약:
+
+- 웹은 **이벤트명만** 전달 (`bridge.haptic('event-name')`)
+- 스타일/횟수는 **RN의 `HAPTIC_PATTERNS` 맵이 소유** — 웹에서 결정 금지
+- 필수 이벤트: 유저 입력(Heavy×1), 성공 클리어(Heavy×6), 게임 완료(Heavy×3)
+
+자세한 가이드는 루트 `CLAUDE.md`의 "Adding a New Game" / "Haptic Feedback" 섹션, `rn/CLAUDE.md`의 "Haptic Feedback" 섹션 참고.
+
+## CI
+
+`.github/workflows/ci.yml`이 `push to main` 및 모든 PR(opened/synchronize/reopened)에서 다음 단계를 실행합니다.
+
+1. pnpm 9.15.4 + Node.js 20 셋업 (pnpm cache)
+2. `pnpm install --frozen-lockfile`
+3. `pnpm typecheck`
+4. `pnpm build`
+5. `pnpm lint`
+6. `pnpm test`
+
+로컬에서 같은 명령을 실행해 PR 전에 검증할 수 있습니다.
 
 ## Team Structure
-
-이 프로젝트는 역할별 폴더를 기준으로 운영됩니다.
 
 | Area | Folder | Role |
 |------|--------|------|
 | Coordinator | `/` (root) | 전체 구조/워크스페이스 조율 |
 | PRD | `prd/` | 게임 기획, 요구사항 정의 |
-| Game Core | `lib/*` | Phaser.io 게임 로직 개발 |
-| Web Frontend | `web/arcade/` | 통합 웹 앱과 라우팅 |
-| RN App | `rn/` | React Native Arcade 앱 |
-| Knowledge | `knowledge/` | 구조, 결정, 진행 기록 |
+| Game Core | `lib/{game}/` | Phaser.io 게임 로직 |
+| Web Frontend | `web/arcade/` | 통합 웹 앱 + 게임 라우트 |
+| RN App | `rn/` | React Native 슈퍼앱 (WebView) |
+| Knowledge | `knowledge/` | 구조/결정/진행 기록 |
 
-## Getting Started
-
-```bash
-# Install dependencies
-pnpm install
-
-# Enable Agent Teams
-export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
-
-# Start Claude and create team
-claude
-/team
-```
-
-## RN WebView 개발 설정
-
-RN 앱은 WebView로 Vite dev server에 접속합니다. 환경별 설정:
-
-| 환경 | 호스트 | 추가 설정 |
-|------|--------|-----------|
-| Android emulator | `10.0.2.2` (자동) | 없음 |
-| iOS simulator | `localhost` (자동) | 없음 |
-| 실기기 (WiFi) | 직접 지정 필요 | `rn/.env` 생성 필요 |
-
-**실기기 연결 시:**
-
-```bash
-# rn/.env 파일 생성 (rn/.env.example 참고)
-echo "EXPO_PUBLIC_DEV_HOST=192.168.1.100" > rn/.env
-
-# Vite dev server 시작 (web/arcade 기준)
-cd web/arcade && pnpm dev
-
-# Expo 시작
-cd rn && npx expo start
-```
-
-> **Note**: `EXPO_PUBLIC_DEV_HOST` 미설정 시 dev 콘솔에 경고 메시지가 출력됩니다. 에뮬레이터/시뮬레이터에서는 자동 기본값이 적용되므로 정상 동작합니다.
-
-## Development Commands
-
-```bash
-# Build all packages that define a build script
-pnpm build
-
-# Type-check all workspace packages without emitting build artifacts
-pnpm typecheck
-
-# Lint all packages
-# Note: this currently fails until at least one workspace package defines a lint script
-pnpm lint
-
-# Test all packages
-# Note: this currently fails until at least one workspace package defines a test script
-pnpm test
-```
+각 폴더의 `CLAUDE.md`에 상세 가이드가 있습니다.
 
 ## Tech Stack
 
-- **Monorepo**: pnpm workspaces
+- **Monorepo**: pnpm workspaces (`pnpm@9.15.4`)
 - **Game Engine**: Phaser.io
-- **Web**: React + TypeScript + Stitches
-- **Mobile**: React Native + WebView
-- **Build**: Vite
+- **Web**: React + TypeScript + Stitches, Vite
+- **Mobile**: Expo SDK 54 + React Native 0.81 + react-native-webview
+- **Quality**: ESLint 10 + Vitest (루트 flat config, 워크스페이스별 확장)
 
 ## Docs
 
 - 지식베이스 인덱스: `knowledge/README.md`
 - 구조 문서: `knowledge/project-structure.md`
-- 기술 결정: `knowledge/architecture-decisions.md`
+- 기술 결정 (ADR): `knowledge/architecture-decisions.md`
 - 변경 이력: `knowledge/decisions.md`
+- 진행 타임라인: `knowledge/progress.md`
+- RN WebView / 브릿지 / 햅틱 상세: `rn/CLAUDE.md`


### PR DESCRIPTION
Closes #238

## Summary

README를 현재 저장소 구조(`lib/{game}` → `web/arcade` → `rn`)와 최신 개발 흐름에 맞춰 재작성했습니다. 신규 기여자가 문서만 보고 로컬 실행과 기본 검증을 수행할 수 있는 상태를 목표로 합니다.

### 주요 변경 사항

- **Architecture**: canonical pipeline을 `lib/{game}` → `web/arcade` → `rn`으로 명시. `web/found3`, `web/crunch3`, `found3/rn`은 남겨두되 **deprecated (legacy)**로 표시.
- **Games table**: `rn/src/data/games.ts`에 등록된 16개 게임을 id / name / category / stages / new 컬럼으로 정리. 파일이 SSoT임을 명시.
- **Getting Started**: `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` / `/team` 내부 도구 언급 제거. 실제 플로우(`pnpm install` → `web/arcade && pnpm dev` → `rn && npx expo start`)만 기재.
- **RN WebView Dev Host**: 표만 유지하고 URL 해상도 · 브릿지 프로토콜은 `rn/CLAUDE.md` 링크로 축약.
- **Development Commands**: `pnpm lint` / `pnpm test`의 "currently fails" 주석 제거(PR #241 이후 정상 동작). `pnpm -r --filter <pkg>` 예시 추가.
- **Adding a New Game**: PRD → `lib/{name}/` → `web/arcade` 라우트 (`registerRoutes()`) → `rn/src/data/games.ts` 등록 → `HAPTIC_PATTERNS` 업데이트 순서를 단계별로 문서화. 햅틱 필수 명시.
- **CI**: `.github/workflows/ci.yml`의 단계(install → typecheck → build → lint → test, push to main + PR)를 요약.
- **Tech Stack / Docs**: Expo SDK 54, RN 0.81, ESLint 10 + Vitest 반영. Docs 링크 목록에 `rn/CLAUDE.md` 추가.

### NOT in scope (의도적으로 손대지 않음)

- `web/found3`, `web/crunch3`, `found3/rn` 패키지는 **삭제하거나 이동하지 않고** "deprecated" 라벨만 부여. 실제 정리는 별도 이슈로 다뤄야 안전.
- `pnpm -r --filter` 예시의 패키지명은 현 `package.json`의 `name`(`@arcade/web`, `@arcade/lib-found3`)을 그대로 반영. 패키지명 리네이밍은 범위 밖.
- `docs/` 폴더로의 분리(이슈 작업 범위에 "필요 시"로 기재됨)는 README 단일 파일 정리만으로 현재 니즈를 충족한다고 판단하여 보류.
- tooling 동작 검증(`pnpm install` / `pnpm lint` 실제 실행)은 worktree에 `node_modules`가 없어 범위 밖. CI가 같은 명령을 실행하므로 기능 확인은 CI에 위임.

## Test plan

- [ ] GitHub에서 렌더링된 README 확인 (표 / 코드 블록 / 링크 정상 동작)
- [ ] `rn/CLAUDE.md`, `knowledge/architecture-decisions.md`, `.github/workflows/ci.yml` 등 내부 링크 유효성 확인
- [ ] 신규 기여자 관점에서 "install → dev → expo start → PR" 흐름이 2분 안에 이해되는지 리뷰

🤖 Generated with [Claude Code](https://claude.com/claude-code)