### PR TITLE
chore(deps): unify workspace dep policy via root pnpm.overrides (#237)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ pnpm test
 - **Mobile**: React Native + WebView
 - **Build**: Vite
 
+See `knowledge/architecture-decisions.md` ADR-019 for the dep version policy.
+
 ## Docs
 
 - 지식베이스 인덱스: `knowledge/README.md`

--- a/knowledge/architecture-decisions.md
+++ b/knowledge/architecture-decisions.md
@@ -378,3 +378,50 @@ rn/src/data/games.ts                         # webPath: '/games/{game-id}/v1'
 - iframe ↔ RN bridge 연동이 필요하면 `window.postMessage` relay 레이어 추가 필요
 - 첫 사례: NEXUS BRAWL (#248, PR #249)
 
+---
+
+## ADR-019: Monorepo Dependency Policy
+
+### Context
+워크스페이스 전반에 걸쳐 핵심 의존성 버전이 흩어져 있었다. `web/*`는 React 18 계열, `rn`은 React 19 계열을 쓰고, `lib/found3-react`에 로컬 `pnpm.overrides`로 `@types/react@18.2.79`를 고정하는 설정이 있어 설치 시 경고가 발생했다. pnpm은 `pnpm.overrides`를 워크스페이스 루트에서만 존중하므로 하위 패키지의 overrides는 아무 효과 없이 경고만 유발한다.
+
+이슈 #237은 이런 분산 상태를 정리하고, 루트 기준으로 "무엇을 왜 고정하는지" 명확히 하는 정책성 작업이다. 대규모 React 업그레이드는 범위 밖으로 명시됐다.
+
+### Decision
+
+1. **React 18 (web/lib) + React 19 (rn) 공존**
+   - RN 0.81은 React 19 요구 (peer dependency)
+   - 웹은 React 18 계열에서 안정적으로 동작 중 — 무리한 통일을 하지 않는다
+2. **TypeScript는 루트 `pnpm.overrides`로 워크스페이스 전체 핀**
+   - 현재 해상도 `5.9.3`을 그대로 고정 (캐럿 특성상 `^5.5.0` 지정자는 5.9.x까지 허용됐음)
+   - 향후 드리프트 방지
+3. **Vite도 루트 `pnpm.overrides`로 워크스페이스 전체 핀**
+   - 현재 해상도 `5.4.21` 고정
+4. **`@types/react`는 루트 overrides에 넣지 않음**
+   - 웹(`^18.3.0`)과 RN(`^19.1.17`)이 **의도적으로** 분리
+   - 루트에서 한 쪽으로 고정하면 반대편 타입이 깨진다
+5. **`pnpm.overrides`는 워크스페이스 루트에만 존재**
+   - 하위 패키지의 `pnpm` 키는 무효 + 경고 유발 → 금지
+   - `lib/found3-react`의 로컬 `pnpm.overrides` 제거, 직접 의존성만 `^18.3.0`으로 정렬
+
+### Version Matrix
+
+| Package | React | ReactDOM | React Native | @types/react | TypeScript | Vite |
+|---------|-------|----------|--------------|--------------|------------|------|
+| `web/arcade` | `^18.3.0` | `^18.3.0` | — | `^18.3.0` | `5.9.3` (pinned) | `5.4.21` (pinned) |
+| `web/found3` | `^18.3.0` | `^18.3.0` | — | `^18.3.0` | `5.9.3` (pinned) | `5.4.21` (pinned) |
+| `web/crunch3` | `^18.3.0` | `^18.3.0` | — | `^18.3.0` | `5.9.3` (pinned) | `5.4.21` (pinned) |
+| `lib/found3-react` | `^18.3.0` | — | — | `^18.3.0` | `5.9.3` (pinned) | — |
+| `rn` | `19.1.0` | — | `0.81.5` | `^19.1.17` | `5.9.3` (pinned) | — |
+
+### Trade-offs
+- **Split `@types/react`**: 공용 라이브러리 코드를 쓸 때 기여자는 React 18의 API surface를 **최소 공통 분모**로 가정하고 작성해야 한다 (e.g. React 19 전용 훅/API 사용 금지).
+- **TypeScript/Vite를 루트에서 고정**: 하위 패키지가 `devDependencies`에 느슨한 캐럿을 유지해도 실제 설치 버전이 하나로 수렴 → lock 안정성↑. 단, 버전을 올릴 땐 루트 overrides를 수정해야 함.
+- **React 공존**: 타입 공유 불가(의도), 런타임은 각자 번들이라 충돌 없음.
+
+### Rationale
+- 설치 경고 제거: 하위 `pnpm.overrides`가 만들던 경고 사라짐
+- 드리프트 방지: TS/Vite 패치 릴리스가 어느 패키지에서 먼저 튀어오르는 상황을 원천 차단
+- 이슈 #237의 "루트 기준 정책" 요구 충족
+- React 대규모 업그레이드는 별도 이슈로 분리 (이 ADR의 비범위)
+

--- a/lib/found3-react/package.json
+++ b/lib/found3-react/package.json
@@ -20,12 +20,7 @@
     "@stitches/react": "^1.2.8"
   },
   "devDependencies": {
-    "@types/react": "18.2.79",
+    "@types/react": "^18.3.0",
     "typescript": "^5.5.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "@types/react": "18.2.79"
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,5 +18,11 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
     "globals": "^17.5.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "typescript": "5.9.3",
+      "vite": "5.4.21"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  typescript: 5.9.3
+  vite: 5.4.21
+
 importers:
 
   .:
@@ -37,7 +41,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/anipang3:
@@ -47,7 +51,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/anipang4:
@@ -57,7 +61,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/arrows:
@@ -67,7 +71,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/blockcrush:
@@ -77,7 +81,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/blockpuzzle:
@@ -87,7 +91,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/blockrush:
@@ -97,7 +101,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/blockyquest:
@@ -107,7 +111,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/brainout:
@@ -117,7 +121,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/buscraze:
@@ -127,7 +131,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/busjam:
@@ -137,7 +141,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/candyfriends:
@@ -147,7 +151,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/candypop:
@@ -157,7 +161,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/carjam:
@@ -167,7 +171,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/carout:
@@ -177,7 +181,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/chess:
@@ -187,7 +191,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/colorslide:
@@ -197,7 +201,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/crunch3:
@@ -207,7 +211,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
       vitest:
         specifier: ^2.1.9
@@ -220,7 +224,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/dop5:
@@ -230,7 +234,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/dreamstore:
@@ -240,7 +244,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/escaperoom:
@@ -250,7 +254,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/fishdom:
@@ -260,7 +264,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/forestpop:
@@ -270,7 +274,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/found3:
@@ -280,7 +284,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
       vitest:
         specifier: ^2.1.9
@@ -296,10 +300,10 @@ importers:
         version: 18.3.1
     devDependencies:
       '@types/react':
-        specifier: 18.2.79
-        version: 18.2.79
+        specifier: ^18.3.0
+        version: 18.3.28
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/getcolor:
@@ -309,7 +313,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/hellotown:
@@ -319,7 +323,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/hexaaway:
@@ -329,7 +333,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/linedraw:
@@ -339,7 +343,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/mahjong-match:
@@ -349,7 +353,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/matchfactory:
@@ -359,7 +363,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/minesweeper:
@@ -369,7 +373,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/mystery-town:
@@ -379,7 +383,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/nonogram:
@@ -389,7 +393,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/number10:
@@ -399,7 +403,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/pixelart:
@@ -409,7 +413,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/pixelflow:
@@ -419,7 +423,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/puzzle3go:
@@ -429,7 +433,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/savedoge:
@@ -439,7 +443,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/screwdom:
@@ -449,7 +453,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/skewerjam:
@@ -459,7 +463,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/slidematch:
@@ -469,7 +473,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/spotdiff:
@@ -479,7 +483,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/spotit:
@@ -489,7 +493,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/starrynight:
@@ -499,7 +503,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/sudoku:
@@ -509,7 +513,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/tangledrope:
@@ -519,7 +523,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/tangram:
@@ -529,7 +533,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/tictactoe:
@@ -539,7 +543,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/tidymaster:
@@ -549,7 +553,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/tileconnect:
@@ -559,7 +563,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/toonblast:
@@ -569,7 +573,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/trafficjam:
@@ -579,7 +583,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/trickyprank:
@@ -589,7 +593,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/trickytwist:
@@ -599,7 +603,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/watersort:
@@ -609,7 +613,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/woodoku:
@@ -619,7 +623,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/wordpuzzle:
@@ -629,7 +633,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   lib/yarnfever:
@@ -639,7 +643,7 @@ importers:
         version: 3.90.0
     devDependencies:
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   rn:
@@ -685,7 +689,7 @@ importers:
         specifier: ^19.1.17
         version: 19.1.17
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
 
   web/arcade:
@@ -893,10 +897,10 @@ importers:
         specifier: ^4.3.0
         version: 4.7.0(vite@5.4.21(@types/node@25.5.0)(lightningcss@1.32.0)(terser@5.46.1))
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: ^5.4.0
+        specifier: 5.4.21
         version: 5.4.21(@types/node@25.5.0)(lightningcss@1.32.0)(terser@5.46.1)
 
   web/crunch3:
@@ -927,10 +931,10 @@ importers:
         specifier: ^4.3.0
         version: 4.7.0(vite@5.4.21(@types/node@25.5.0)(lightningcss@1.32.0)(terser@5.46.1))
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: ^5.4.0
+        specifier: 5.4.21
         version: 5.4.21(@types/node@25.5.0)(lightningcss@1.32.0)(terser@5.46.1)
 
   web/found3:
@@ -961,10 +965,10 @@ importers:
         specifier: ^4.3.0
         version: 4.7.0(vite@5.4.21(@types/node@25.5.0)(lightningcss@1.32.0)(terser@5.46.1))
       typescript:
-        specifier: ^5.5.0
+        specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: ^5.4.0
+        specifier: 5.4.21
         version: 5.4.21(@types/node@25.5.0)(lightningcss@1.32.0)(terser@5.46.1)
 
 packages:
@@ -2127,9 +2131,6 @@ packages:
     peerDependencies:
       '@types/react': ^18.0.0
 
-  '@types/react@18.2.79':
-    resolution: {integrity: sha512-RwGAGXPl9kSXwdNTafkOEuFrTBD5SA2B3iEB96xi8+xu5ddUa/cpvyVCSNn+asgLCTHkb5ZxN8gbuibYJi4s1w==}
-
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
 
@@ -2151,20 +2152,20 @@ packages:
     peerDependencies:
       '@typescript-eslint/parser': ^8.59.0
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: 5.9.3
 
   '@typescript-eslint/parser@8.59.0':
     resolution: {integrity: sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: 5.9.3
 
   '@typescript-eslint/project-service@8.59.0':
     resolution: {integrity: sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: 5.9.3
 
   '@typescript-eslint/scope-manager@8.59.0':
     resolution: {integrity: sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==}
@@ -2174,14 +2175,14 @@ packages:
     resolution: {integrity: sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: 5.9.3
 
   '@typescript-eslint/type-utils@8.59.0':
     resolution: {integrity: sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: 5.9.3
 
   '@typescript-eslint/types@8.59.0':
     resolution: {integrity: sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==}
@@ -2191,14 +2192,14 @@ packages:
     resolution: {integrity: sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: 5.9.3
 
   '@typescript-eslint/utils@8.59.0':
     resolution: {integrity: sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: 5.9.3
 
   '@typescript-eslint/visitor-keys@8.59.0':
     resolution: {integrity: sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==}
@@ -2219,7 +2220,7 @@ packages:
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+      vite: 5.4.21
 
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
@@ -2228,7 +2229,7 @@ packages:
     resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0
+      vite: 5.4.21
     peerDependenciesMeta:
       msw:
         optional: true
@@ -4439,7 +4440,7 @@ packages:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
     peerDependencies:
-      typescript: '>=4.8.4'
+      typescript: 5.9.3
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
@@ -6183,11 +6184,6 @@ snapshots:
   '@types/react-dom@18.3.7(@types/react@18.3.28)':
     dependencies:
       '@types/react': 18.3.28
-
-  '@types/react@18.2.79':
-    dependencies:
-      '@types/prop-types': 15.7.15
-      csstype: 3.2.3
 
   '@types/react@18.3.28':
     dependencies:


### PR DESCRIPTION
Closes #237

## Summary

Makes the monorepo dependency policy explicit and workspace-rooted. Pins TypeScript and Vite at the workspace root via `pnpm.overrides`, and removes the non-functional local `pnpm.overrides` in `lib/found3-react` that was producing install warnings.

Not a mass upgrade. React 18/19 split is intentional and preserved. Policy is documented in ADR-019.

## Version Matrix

### Before

| Package | TypeScript | Vite | @types/react | Notes |
|---------|------------|------|--------------|-------|
| `web/arcade` | `^5.5.0` → resolved `5.9.3` | `^5.4.0` → `5.4.21` | `^18.3.0` → `18.3.28` | |
| `web/found3` | `^5.5.0` → `5.9.3` | `^5.4.0` → `5.4.21` | `^18.3.0` → `18.3.28` | |
| `web/crunch3` | `^5.5.0` → `5.9.3` | `^5.4.0` → `5.4.21` | `^18.3.0` → `18.3.28` | |
| `lib/found3-react` | `^5.5.0` → `5.9.3` | — | **exact `18.2.79`** + local `pnpm.overrides` | warning on install |
| `rn` | `^5.5.0` → `5.9.3` | — | `^19.1.17` → `19.1.17` | |

### After

| Package | TypeScript | Vite | @types/react | Notes |
|---------|------------|------|--------------|-------|
| `web/arcade` | **`5.9.3` (root override)** | **`5.4.21` (root override)** | `^18.3.0` → `18.3.28` | |
| `web/found3` | **`5.9.3` (root override)** | **`5.4.21` (root override)** | `^18.3.0` → `18.3.28` | |
| `web/crunch3` | **`5.9.3` (root override)** | **`5.4.21` (root override)** | `^18.3.0` → `18.3.28` | |
| `lib/found3-react` | **`5.9.3` (root override)** | — | **`^18.3.0` → `18.3.28`** | local overrides removed |
| `rn` | **`5.9.3` (root override)** | — | `^19.1.17` → `19.1.17` | |

Day-1 resolved versions are unchanged (no-op pinning). Only `lib/found3-react`'s `@types/react` moves 18.2.79 → 18.3.28 to align with the rest of web. Typecheck passes (`pnpm -r typecheck`, all 14 packages green).

## Policy (see ADR-019)

1. React 18 (web/lib) + React 19 (rn) coexist — RN 0.81 requires 19, web stable on 18.
2. TypeScript pinned workspace-wide via root `pnpm.overrides` → `5.9.3`.
3. Vite pinned workspace-wide via root `pnpm.overrides` → `5.4.21`.
4. `@types/react` intentionally NOT in root overrides — split by package family (web `^18.3.0`, rn `^19.1.17`).
5. `pnpm.overrides` lives at workspace root only — hub for version policy.

## Files Changed

- `package.json` — added `pnpm.overrides` for `typescript` and `vite`
- `lib/found3-react/package.json` — removed `pnpm` key, bumped `@types/react` 18.2.79 → `^18.3.0`
- `knowledge/architecture-decisions.md` — ADR-019 added
- `README.md` — one-line pointer to ADR-019 in Tech Stack section
- `pnpm-lock.yaml` — regenerated (diff: +83/-87, only specifier pins + 18.2.79 removal, no unrelated bumps)

## Issue Checklist

- [x] 전체 workspace 핵심 의존성 버전 매트릭스 작성 (above + ADR-019)
- [x] 실제 충돌 가능성이 높은 패키지 식별 (`lib/found3-react` — fixed)
- [x] 루트에서 관리할 override/constraints 정책 정리 (root `pnpm.overrides`)
- [x] 하위 패키지의 개별 override 제거 검토 (removed from `lib/found3-react`)
- [x] React 18/19 공존이 필요한지, 통일이 가능한지 판단 (공존 유지 — 상세는 ADR-019)
- [x] 정책 결과를 README 또는 개발 문서에 반영 (README + ADR-019)

**Deferred (explicitly out of scope per issue's 비범위 section):** mass React/react-dom/react-native upgrade. Split `@types/react` unification (would require React 19 upgrade on web).

## Test Plan

- [x] `pnpm install` — clean, no more `lib/found3-react` local-overrides warning
- [x] `pnpm -r typecheck` — all 14 packages green
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)