### PR TITLE
fix(neon-vanguard): narrow skill union and guard null targets to unblock typecheck

### DIFF
--- a/web/arcade/src/games/neon-vanguard/ArenaGame.tsx
+++ b/web/arcade/src/games/neon-vanguard/ArenaGame.tsx
@@ -366,19 +366,21 @@ class Character extends GameObject {
   }
 
   useSkill(key: SkillKey, target: Vec2) {
-    const skill = this.heroDef.skills[key];
-    if (!skill) return;
-
     const cdMult = this.buffs.find((buff) => buff.type === 'overdrive') ? 0.5 : 1;
 
     if (key === 'ultimate') {
-      if (this.ultCharge >= skill.cost) {
+      const ultimate = this.heroDef.skills.ultimate;
+      if (!ultimate) return;
+      if (this.ultCharge >= ultimate.cost) {
         this.ultCharge = 0;
-        skill.use(this.engine, this, target);
+        ultimate.use(this.engine, this, target);
         if (this.isPlayer) haptic('ultimate');
       }
       return;
     }
+
+    const skill = this.heroDef.skills[key];
+    if (!skill) return;
 
     if (this.cds[key] <= 0) {
       this.cds[key] = skill.cd * cdMult;
@@ -912,7 +914,7 @@ class GameEngine {
     const allies = this.entities.filter((entity) => entity.active && entity.team === bot.team && entity !== bot);
     const enemies = this.entities.filter((entity) => entity.active && entity.team !== bot.team);
 
-    let enemy: Character | null = null;
+    let enemy = null as Character | null;
     let enemyDist = Number.POSITIVE_INFINITY;
     enemies.forEach((candidate) => {
       const dist = bot.pos.dist(candidate.pos);
@@ -923,7 +925,7 @@ class GameEngine {
     });
 
     const isSupport = bot.heroDef.role === 'Support';
-    let healTarget: Character | null = null;
+    let healTarget = null as Character | null;
     if (isSupport) {
       let lowestHpRatio = 0.8;
       allies.forEach((ally) => {


### PR DESCRIPTION
## Why

`main` was broken: `pnpm typecheck` on `@arcade/web` failed with **14 TypeScript errors** in `web/arcade/src/games/neon-vanguard/ArenaGame.tsx`. Because workspace CI runs `pnpm -r typecheck` against current main state, **every open PR has been failing CI** since the breakage landed. This PR unblocks CI for all pending PRs.

## Fixed errors

From failing CI run `24873171850`:

```
ArenaGame.tsx(375,35): TS2339 Property 'cost' does not exist on type 'SkillDef | UltimateSkillDef'.
ArenaGame.tsx(384,29): TS2339 Property 'cd' does not exist on type 'SkillDef | UltimateSkillDef'.
ArenaGame.tsx(943,30): TS2339 Property 'pos' does not exist on type 'never'.
ArenaGame.tsx(944,31): TS2339 Property 'pos' does not exist on type 'never'.
ArenaGame.tsx(946,61): TS2339 Property 'pos' does not exist on type 'never'.
ArenaGame.tsx(947,57): TS2345 Argument of type 'Vec2 | null' is not assignable to 'Vec2'.
ArenaGame.tsx(950,25): TS2339 Property 'pos' does not exist on type 'never'.
ArenaGame.tsx(951,26): TS2339 Property 'pos' does not exist on type 'never'.
ArenaGame.tsx(952,57): TS2345 Argument of type 'Vec2 | null' is not assignable to 'Vec2'.
ArenaGame.tsx(953,..): TS2345 Vec2 | null not assignable to Vec2.
ArenaGame.tsx(954,..): TS2345 Vec2 | null not assignable to Vec2.
ArenaGame.tsx(955,..): TS2345 Vec2 | null not assignable to Vec2.
ArenaGame.tsx(956,..): TS2345 Vec2 | null not assignable to Vec2.
```

**Before: 14 type errors. After: 0.**

## How

Minimal typing-only changes, no runtime behavior change.

1. **`useSkill` (skill union narrowing)** — The `heroDef.skills[key]` lookup returns `SkillDef | UltimateSkillDef`, and TS doesn't narrow the union across the `key === 'ultimate'` branch. Fixed by accessing `heroDef.skills.ultimate` directly inside the ultimate branch (already typed `UltimateSkillDef`, has `.cost`) and `heroDef.skills[key]` only in the cooldown branch where `key` excludes `'ultimate'` (so it narrows to `SkillDef`, has `.cd`).

2. **`updateAI` (closure-narrowing collapse to `never`)** — `let enemy: Character | null = null` with assignments only inside `forEach` callbacks triggered TS's closure-narrowing to collapse subsequent `if (enemy)` / `if (healTarget)` checks down to `never`, which then failed on `.pos` access. Changed declarations to `let enemy = null as Character | null` / `let healTarget = null as Character | null` so TS preserves the union type past the `forEach`. The `if (healTarget)` / `else if (enemy)` guards then narrow correctly and `aimTarget` / `moveTarget` become `Vec2` before being passed to `useSkill(Vec2)`.

No `@ts-ignore`, no `@ts-nocheck`, no `as any`, no tsconfig exclusions.

## Verification

```
$ pnpm --filter @arcade/web typecheck
> tsc --noEmit  (clean)

$ pnpm -r typecheck
Scope: 64 of 65 workspace projects
... all packages report: typecheck: Done
```

Full workspace typecheck passes. Ready to merge and unblock CI.

## Test plan

- [x] `pnpm --filter @arcade/web typecheck` passes locally
- [x] `pnpm -r typecheck` passes locally (all 64 workspace packages)
- [ ] CI workspace typecheck passes on this PR