### PR TITLE
feat(chess): implement SAN generation and move history UI

### DIFF
--- a/lib/chess/src/logic/rules.ts
+++ b/lib/chess/src/logic/rules.ts
@@ -26,6 +26,59 @@ export function inBounds(row: number, col: number): boolean {
 
 const opposite = (c: Color): Color => (c === 'w' ? 'b' : 'w');
 
+export function sqToName(s: Square): string {
+  return String.fromCharCode(97 + colOf(s)) + (8 - rowOf(s));
+}
+
+export function moveToSAN(state: BoardState, move: Move, nextStatus: BoardState['status']): string {
+  if (move.isCastle) {
+    return move.isCastle === 'k' ? 'O-O' : 'O-O-O';
+  }
+
+  const piece = state.board[move.from];
+  if (!piece) return '';
+
+  let san = '';
+  if (piece.type === 'p') {
+    if (move.captured || move.isEnPassant) {
+      san += String.fromCharCode(97 + colOf(move.from)) + 'x';
+    }
+  } else {
+    san += piece.type.toUpperCase();
+
+    // Disambiguation: find other pieces of same type that could move to the same square
+    const others = getAllLegalMoves(state, piece.color).filter(
+      (m) => m.to === move.to && m.from !== move.from && state.board[m.from]?.type === piece.type
+    );
+
+    if (others.length > 0) {
+      const sameFile = others.some((m) => colOf(m.from) === colOf(move.from));
+      const sameRank = others.some((m) => rowOf(m.from) === rowOf(move.from));
+
+      if (!sameFile) {
+        san += String.fromCharCode(97 + colOf(move.from));
+      } else if (!sameRank) {
+        san += (8 - rowOf(move.from)).toString();
+      } else {
+        san += String.fromCharCode(97 + colOf(move.from)) + (8 - rowOf(move.from));
+      }
+    }
+
+    if (move.captured) san += 'x';
+  }
+
+  san += sqToName(move.to);
+
+  if (move.promotion) {
+    san += '=' + move.promotion.toUpperCase();
+  }
+
+  if (nextStatus === 'checkmate') san += '#';
+  else if (nextStatus === 'check') san += '+';
+
+  return san;
+}
+
 // ─── Initial position ──────────────────────────────────────
 
 export function createInitialBoard(): BoardState {
@@ -51,6 +104,7 @@ export function createInitialBoard(): BoardState {
     lastMove: null,
     positionHistory: {},
     clocks: { w: 600000, b: 600000 },
+    history: [],
   };
   initial.positionHistory[hashPosition(initial)] = 1;
   return initial;
@@ -469,6 +523,7 @@ export function applyMove(state: BoardState, move: Move): BoardState {
     lastMove: { ...move, captured },
     positionHistory,
     clocks: { ...state.clocks },
+    history: [...state.history],
   };
 
   const hash = hashPosition(next);
@@ -477,6 +532,10 @@ export function applyMove(state: BoardState, move: Move): BoardState {
   const statusInfo = getGameStatus(next);
   next.status = statusInfo.status;
   next.winner = statusInfo.winner;
+
+  // Generate SAN and add to history
+  next.history.push(moveToSAN(state, move, next.status));
+
   return next;
 }
 

--- a/lib/chess/src/scenes/PlayScene.ts
+++ b/lib/chess/src/scenes/PlayScene.ts
@@ -200,7 +200,35 @@ export class PlayScene extends Phaser.Scene {
     }
 
     this.drawStatus();
+    this.drawMoveHistory();
     this.drawPromotionPrompt();
+  }
+
+  private drawMoveHistory() {
+    const scale = this.dpr;
+    const width = DEFAULT_WIDTH * scale;
+
+    let historyText = '';
+    const history = this.state.history;
+    for (let i = 0; i < history.length; i += 2) {
+      const moveNum = Math.floor(i / 2) + 1;
+      const whiteMove = history[i];
+      const blackMove = history[i + 1] || '';
+      historyText += `${moveNum}. ${whiteMove} ${blackMove}  `;
+    }
+
+    const turns = historyText.trim().split('  ');
+    if (turns.length > 3) {
+      historyText = '... ' + turns.slice(-3).join('  ');
+    }
+
+    const y = this.boardOriginY - 52 * scale;
+    const text = this.add.text(width / 2, y, historyText.trim(), {
+      fontSize: `${13 * scale}px`,
+      fontFamily: 'system-ui, sans-serif',
+      color: '#9CA3AF',
+    });
+    text.setOrigin(0.5);
   }
 
   private tintSquare(square: Square, color: number, alpha: number) {

--- a/lib/chess/src/types.ts
+++ b/lib/chess/src/types.ts
@@ -53,6 +53,7 @@ export interface BoardState {
   lastMove: Move | null;
   positionHistory: Record<string, number>; // hash -> count for 3-fold repetition
   clocks: { w: number; b: number }; // remaining milliseconds
+  history: string[]; // SAN strings
 }
 
 export type Difficulty = 'easy' | 'medium' | 'hard';


### PR DESCRIPTION
## Summary
This PR implements SAN (Standard Algebraic Notation) generation and a move history display.

### Changes
- **SAN Generation (#229)**: The engine now generates full SAN strings (e.g., `Nf3`, `exd5`, `O-O`, `e8=Q#`) for every move, including disambiguation logic.
- **Move History (#229)**: `BoardState` now maintains a `history` array of SAN strings.
- **UI Display (#229)**: The game scene now displays the move history above the board, showing the last few turns (e.g., `1. e4 e5  2. Nf3 ...`).

## Verification
- Built `@arcade/lib-chess` successfully.
- Verified SAN logic for complex cases (disambiguation, checkmate).

Closes #229