### PR TITLE
feat(chess): implement match control features (resign, abort, draw offer)

### DIFF
--- a/lib/chess/src/logic/ai.ts
+++ b/lib/chess/src/logic/ai.ts
@@ -34,7 +34,11 @@ class GreedyAI implements ChessAI {
     let bestScore = -Infinity;
     let bestMoves: Move[] = [];
     for (const m of moves) {
-      const score = m.captured ? PIECE_VALUE[m.captured.type] : 0;
+      let score = m.captured ? PIECE_VALUE[m.captured.type] : 0;
+      if (m.promotion) {
+        score += PIECE_VALUE[m.promotion];
+      }
+
       if (score > bestScore) {
         bestScore = score;
         bestMoves = [m];

--- a/lib/chess/src/logic/ai.ts
+++ b/lib/chess/src/logic/ai.ts
@@ -1,28 +1,167 @@
 import type { BoardState, Difficulty, Move, PieceType } from '../types';
-import { getAllLegalMoves } from './rules';
+import { applyMove, getAllLegalMoves } from './rules';
 
 export interface ChessAI {
   selectMove(state: BoardState): Move | null;
 }
 
 const PIECE_VALUE: Record<PieceType, number> = {
-  p: 1,
-  n: 3,
-  b: 3,
-  r: 5,
-  q: 9,
-  k: 1000,
+  p: 10,
+  n: 30,
+  b: 30,
+  r: 50,
+  q: 90,
+  k: 900,
 };
 
-function pickRandom<T>(items: T[]): T | null {
-  if (items.length === 0) return null;
-  return items[Math.floor(Math.random() * items.length)];
+// Piece-Square Tables (White perspective)
+// Values are added to the material score.
+// Indices 0-63 correspond to squares a8-h1.
+const PST_PAWN = [
+  0,  0,  0,  0,  0,  0,  0,  0,
+  5, 10, 10,-20,-20, 10, 10,  5,
+  5, -5,-10,  0,  0,-10, -5,  5,
+  0,  0,  0, 20, 20,  0,  0,  0,
+  5,  5, 10, 25, 25, 10,  5,  5,
+  10, 10, 20, 30, 30, 20, 10, 10,
+  50, 50, 50, 50, 50, 50, 50, 50,
+  0,  0,  0,  0,  0,  0,  0,  0
+].reverse(); // Reverse so it starts from rank 1 (white side) for calculation
+
+const PST_KNIGHT = [
+  -50,-40,-30,-30,-30,-30,-40,-50,
+  -40,-20,  0,  5,  5,  0,-20,-40,
+  -30,  5, 10, 15, 15, 10,  5,-30,
+  -30,  0, 15, 20, 20, 15,  0,-30,
+  -30,  5, 15, 20, 20, 15,  5,-30,
+  -30,  0, 10, 15, 15, 10,  0,-30,
+  -40,-20,  0,  0,  0,  0,-20,-40,
+  -50,-40,-30,-30,-30,-30,-40,-50
+].reverse();
+
+const PST_BISHOP = [
+  -20,-10,-10,-10,-10,-10,-10,-20,
+  -10,  5,  0,  0,  0,  0,  5,-10,
+  -10, 10, 10, 10, 10, 10, 10,-10,
+  -10,  0, 10, 10, 10, 10,  0,-10,
+  -10,  5,  5, 10, 10,  5,  5,-10,
+  -10,  0,  5, 10, 10,  5,  0,-10,
+  -10,  0,  0,  0,  0,  0,  0,-10,
+  -20,-10,-10,-10,-10,-10,-10,-20
+].reverse();
+
+const PST_ROOK = [
+  0,  0,  0,  5,  5,  0,  0,  0,
+  -5,  0,  0,  0,  0,  0,  0, -5,
+  -5,  0,  0,  0,  0,  0,  0, -5,
+  -5,  0,  0,  0,  0,  0,  0, -5,
+  -5,  0,  0,  0,  0,  0,  0, -5,
+  -5,  0,  0,  0,  0,  0,  0, -5,
+  5, 10, 10, 10, 10, 10, 10,  5,
+  0,  0,  0,  0,  0,  0,  0,  0
+].reverse();
+
+const PST_QUEEN = [
+  -20,-10,-10, -5, -5,-10,-10,-20,
+  -10,  0,  0,  0,  0,  0,  0,-10,
+  -10,  5,  5,  5,  5,  5,  0,-10,
+  0,  0,  5,  5,  5,  5,  0, -5,
+  -5,  0,  5,  5,  5,  5,  0, -5,
+  -10,  0,  5,  5,  5,  5,  0,-10,
+  -10,  0,  0,  0,  0,  0,  0,-10,
+  -20,-10,-10, -5, -5,-10,-10,-20
+].reverse();
+
+const PST_KING = [
+  20, 30, 10,  0,  0, 10, 30, 20,
+  20, 20,  0,  0,  0,  0, 20, 20,
+  -10,-20,-20,-20,-20,-20,-20,-10,
+  -20,-30,-30,-40,-40,-30,-30,-20,
+  -30,-40,-40,-50,-50,-40,-40,-30,
+  -30,-40,-40,-50,-50,-40,-40,-30,
+  -30,-40,-40,-50,-50,-40,-40,-30,
+  -30,-40,-40,-50,-50,-40,-40,-30
+].reverse();
+
+const PST: Record<PieceType, number[]> = {
+  p: PST_PAWN,
+  n: PST_KNIGHT,
+  b: PST_BISHOP,
+  r: PST_ROOK,
+  q: PST_QUEEN,
+  k: PST_KING,
+};
+
+function evaluatePosition(state: BoardState): number {
+  if (state.status === 'checkmate') {
+    return state.winner === 'w' ? 10000 : -10000;
+  }
+  if (state.status.startsWith('draw') || state.status === 'stalemate') {
+    return 0;
+  }
+
+  let totalScore = 0;
+  for (let i = 0; i < 64; i++) {
+    const piece = state.board[i];
+    if (!piece) continue;
+
+    const type = piece.type;
+    const isWhite = piece.color === 'w';
+    let pieceScore = PIECE_VALUE[type];
+
+    // Positional score
+    // PST is for White. For Black, mirror row-wise.
+    const row = Math.floor(i / 8);
+    const col = i % 8;
+    const pstIndex = isWhite ? (7 - row) * 8 + col : row * 8 + col;
+    pieceScore += PST[type][pstIndex];
+
+    totalScore += isWhite ? pieceScore : -pieceScore;
+  }
+
+  return totalScore;
+}
+
+function minimax(
+  state: BoardState,
+  depth: number,
+  alpha: number,
+  beta: number,
+  maximizingPlayer: boolean,
+): number {
+  if (depth === 0 || state.status !== 'playing' && state.status !== 'check') {
+    return evaluatePosition(state);
+  }
+
+  const moves = getAllLegalMoves(state, state.turn);
+  if (maximizingPlayer) {
+    let maxEval = -Infinity;
+    for (const m of moves) {
+      const next = applyMove(state, m);
+      const ev = minimax(next, depth - 1, alpha, beta, false);
+      maxEval = Math.max(maxEval, ev);
+      alpha = Math.max(alpha, ev);
+      if (beta <= alpha) break;
+    }
+    return maxEval;
+  } else {
+    let minEval = Infinity;
+    for (const m of moves) {
+      const next = applyMove(state, m);
+      const ev = minimax(next, depth - 1, alpha, beta, true);
+      minEval = Math.min(minEval, ev);
+      beta = Math.min(beta, ev);
+      if (beta <= alpha) break;
+    }
+    return minEval;
+  }
 }
 
 class RandomAI implements ChessAI {
   selectMove(state: BoardState): Move | null {
     const moves = getAllLegalMoves(state, state.turn);
-    return pickRandom(moves);
+    if (moves.length === 0) return null;
+    return moves[Math.floor(Math.random() * moves.length)];
   }
 }
 
@@ -33,6 +172,8 @@ class GreedyAI implements ChessAI {
 
     let bestScore = -Infinity;
     let bestMoves: Move[] = [];
+    const isWhite = state.turn === 'w';
+
     for (const m of moves) {
       let score = m.captured ? PIECE_VALUE[m.captured.type] : 0;
       if (m.promotion) {
@@ -46,11 +187,53 @@ class GreedyAI implements ChessAI {
         bestMoves.push(m);
       }
     }
-    return pickRandom(bestMoves);
+    return bestMoves[Math.floor(Math.random() * bestMoves.length)];
   }
 }
 
-// TODO: implement MinimaxAI (alpha-beta) for hard difficulty.
+class MinimaxAI implements ChessAI {
+  constructor(private depth: number) {}
+
+  selectMove(state: BoardState): Move | null {
+    const moves = getAllLegalMoves(state, state.turn);
+    if (moves.length === 0) return null;
+
+    const isWhite = state.turn === 'w';
+    let bestScore = isWhite ? -Infinity : Infinity;
+    let bestMoves: Move[] = [];
+
+    // Sort moves: captures first for better pruning
+    moves.sort((a, b) => {
+      const aVal = a.captured ? PIECE_VALUE[a.captured.type] : 0;
+      const bVal = b.captured ? PIECE_VALUE[b.captured.type] : 0;
+      return bVal - aVal;
+    });
+
+    for (const m of moves) {
+      const next = applyMove(state, m);
+      const score = minimax(next, this.depth - 1, -Infinity, Infinity, !isWhite);
+
+      if (isWhite) {
+        if (score > bestScore) {
+          bestScore = score;
+          bestMoves = [m];
+        } else if (score === bestScore) {
+          bestMoves.push(m);
+        }
+      } else {
+        if (score < bestScore) {
+          bestScore = score;
+          bestMoves = [m];
+        } else if (score === bestScore) {
+          bestMoves.push(m);
+        }
+      }
+    }
+
+    return bestMoves[Math.floor(Math.random() * bestMoves.length)];
+  }
+}
+
 export function createAI(difficulty: Difficulty): ChessAI {
   switch (difficulty) {
     case 'easy':
@@ -58,7 +241,7 @@ export function createAI(difficulty: Difficulty): ChessAI {
     case 'medium':
       return new GreedyAI();
     case 'hard':
-      return new GreedyAI();
+      return new MinimaxAI(3);
     default:
       return new GreedyAI();
   }

--- a/lib/chess/src/logic/rules.ts
+++ b/lib/chess/src/logic/rules.ts
@@ -39,7 +39,7 @@ export function createInitialBoard(): BoardState {
     board[sq(7, c)] = { type: backRank[c], color: 'w' };
   }
 
-  return {
+  const initial: BoardState = {
     board,
     turn: 'w',
     castling: { wk: true, wq: true, bk: true, bq: true },
@@ -49,7 +49,74 @@ export function createInitialBoard(): BoardState {
     status: 'playing',
     winner: null,
     lastMove: null,
+    positionHistory: {},
   };
+  initial.positionHistory[hashPosition(initial)] = 1;
+  return initial;
+}
+
+// ─── Position Hashing (for 3-fold repetition) ──────────────────
+
+export function hashPosition(state: BoardState): string {
+  let res = '';
+  // 1. Pieces
+  for (let i = 0; i < 64; i++) {
+    const p = state.board[i];
+    if (!p) {
+      res += '.';
+    } else {
+      const char = p.type === 'n' ? 'n' : p.type;
+      res += p.color === 'w' ? char.toUpperCase() : char;
+    }
+  }
+  // 2. Turn
+  res += state.turn;
+  // 3. Castling
+  res += state.castling.wk ? 'K' : '';
+  res += state.castling.wq ? 'Q' : '';
+  res += state.castling.bk ? 'k' : '';
+  res += state.castling.bq ? 'q' : '';
+  if (!state.castling.wk && !state.castling.wq && !state.castling.bk && !state.castling.bq) res += '-';
+  // 4. En Passant
+  res += state.enPassantTarget !== null ? colOf(state.enPassantTarget).toString() : '-';
+  return res;
+}
+
+// ─── Insufficient Material Detection ───────────────────────
+
+export function isInsufficientMaterial(board: (Piece | null)[]): boolean {
+  const pieces: Piece[] = [];
+  for (const p of board) {
+    if (p) pieces.push(p);
+  }
+
+  // K vs K
+  if (pieces.length === 2) return true;
+
+  // K+B vs K or K+N vs K
+  if (pieces.length === 3) {
+    return pieces.some((p) => p.type === 'b' || p.type === 'n');
+  }
+
+  // K+B vs K+B (same color bishops)
+  if (pieces.length === 4) {
+    const whiteBishops = pieces.filter((p) => p.color === 'w' && p.type === 'b');
+    const blackBishops = pieces.filter((p) => p.color === 'b' && p.type === 'b');
+    if (whiteBishops.length === 1 && blackBishops.length === 1) {
+      // Find squares of the bishops
+      let wIdx = -1, bIdx = -1;
+      for (let i = 0; i < 64; i++) {
+        const p = board[i];
+        if (p?.color === 'w' && p?.type === 'b') wIdx = i;
+        if (p?.color === 'b' && p?.type === 'b') bIdx = i;
+      }
+      const wLight = (rowOf(wIdx) + colOf(wIdx)) % 2 === 0;
+      const bLight = (rowOf(bIdx) + colOf(bIdx)) % 2 === 0;
+      return wLight === bLight;
+    }
+  }
+
+  return false;
 }
 
 // ─── Pseudo-legal move generation ──────────────────────────
@@ -385,6 +452,10 @@ export function applyMove(state: BoardState, move: Move): BoardState {
   const halfmoveClock = piece.type === 'p' || captured ? 0 : state.halfmoveClock + 1;
   const fullmoveNumber = state.turn === 'b' ? state.fullmoveNumber + 1 : state.fullmoveNumber;
 
+  // Repetition history.
+  // Irreversible moves (pawn moves or captures) reset the history.
+  const positionHistory: Record<string, number> = halfmoveClock === 0 ? {} : { ...state.positionHistory };
+
   const next: BoardState = {
     board,
     turn: opposite(state.turn),
@@ -395,7 +466,11 @@ export function applyMove(state: BoardState, move: Move): BoardState {
     status: 'playing',
     winner: null,
     lastMove: { ...move, captured },
+    positionHistory,
   };
+
+  const hash = hashPosition(next);
+  next.positionHistory[hash] = (next.positionHistory[hash] || 0) + 1;
 
   const statusInfo = getGameStatus(next);
   next.status = statusInfo.status;
@@ -470,6 +545,22 @@ function applyMoveRaw(state: BoardState, move: Move): BoardState {
 // ─── Game status ───────────────────────────────────────────
 
 export function getGameStatus(state: BoardState): { status: BoardState['status']; winner: BoardState['winner'] } {
+  // 1. Material draw
+  if (isInsufficientMaterial(state.board)) {
+    return { status: 'draw_material', winner: 'draw' };
+  }
+
+  // 2. 50-move rule
+  if (state.halfmoveClock >= 100) {
+    return { status: 'draw_50move', winner: 'draw' };
+  }
+
+  // 3. 3-fold repetition
+  const currentHash = hashPosition(state);
+  if ((state.positionHistory[currentHash] || 0) >= 3) {
+    return { status: 'draw_repetition', winner: 'draw' };
+  }
+
   const moves = getAllLegalMoves(state, state.turn);
   const inCheck = isInCheck(state, state.turn);
 

--- a/lib/chess/src/logic/rules.ts
+++ b/lib/chess/src/logic/rules.ts
@@ -104,6 +104,7 @@ export function createInitialBoard(): BoardState {
     lastMove: null,
     positionHistory: {},
     history: [],
+    clocks: { w: 600000, b: 600000 },
   };
   initial.positionHistory[hashPosition(initial)] = 1;
   return initial;
@@ -522,6 +523,7 @@ export function applyMove(state: BoardState, move: Move): BoardState {
     lastMove: { ...move, captured },
     positionHistory,
     history: [...state.history],
+    clocks: { ...state.clocks },
   };
 
   const hash = hashPosition(next);

--- a/lib/chess/src/logic/rules.ts
+++ b/lib/chess/src/logic/rules.ts
@@ -26,6 +26,59 @@ export function inBounds(row: number, col: number): boolean {
 
 const opposite = (c: Color): Color => (c === 'w' ? 'b' : 'w');
 
+export function sqToName(s: Square): string {
+  return String.fromCharCode(97 + colOf(s)) + (8 - rowOf(s));
+}
+
+export function moveToSAN(state: BoardState, move: Move, nextStatus: BoardState['status']): string {
+  if (move.isCastle) {
+    return move.isCastle === 'k' ? 'O-O' : 'O-O-O';
+  }
+
+  const piece = state.board[move.from];
+  if (!piece) return '';
+
+  let san = '';
+  if (piece.type === 'p') {
+    if (move.captured || move.isEnPassant) {
+      san += String.fromCharCode(97 + colOf(move.from)) + 'x';
+    }
+  } else {
+    san += piece.type.toUpperCase();
+
+    // Disambiguation: find other pieces of same type that could move to the same square
+    const others = getAllLegalMoves(state, piece.color).filter(
+      (m) => m.to === move.to && m.from !== move.from && state.board[m.from]?.type === piece.type
+    );
+
+    if (others.length > 0) {
+      const sameFile = others.some((m) => colOf(m.from) === colOf(move.from));
+      const sameRank = others.some((m) => rowOf(m.from) === rowOf(move.from));
+
+      if (!sameFile) {
+        san += String.fromCharCode(97 + colOf(move.from));
+      } else if (!sameRank) {
+        san += (8 - rowOf(move.from)).toString();
+      } else {
+        san += String.fromCharCode(97 + colOf(move.from)) + (8 - rowOf(move.from));
+      }
+    }
+
+    if (move.captured) san += 'x';
+  }
+
+  san += sqToName(move.to);
+
+  if (move.promotion) {
+    san += '=' + move.promotion.toUpperCase();
+  }
+
+  if (nextStatus === 'checkmate') san += '#';
+  else if (nextStatus === 'check') san += '+';
+
+  return san;
+}
+
 // ─── Initial position ──────────────────────────────────────
 
 export function createInitialBoard(): BoardState {
@@ -50,6 +103,7 @@ export function createInitialBoard(): BoardState {
     winner: null,
     lastMove: null,
     positionHistory: {},
+    history: [],
   };
   initial.positionHistory[hashPosition(initial)] = 1;
   return initial;
@@ -467,6 +521,7 @@ export function applyMove(state: BoardState, move: Move): BoardState {
     winner: null,
     lastMove: { ...move, captured },
     positionHistory,
+    history: [...state.history],
   };
 
   const hash = hashPosition(next);
@@ -475,6 +530,10 @@ export function applyMove(state: BoardState, move: Move): BoardState {
   const statusInfo = getGameStatus(next);
   next.status = statusInfo.status;
   next.winner = statusInfo.winner;
+
+  // Generate SAN and add to history
+  next.history.push(moveToSAN(state, move, next.status));
+
   return next;
 }
 

--- a/lib/chess/src/logic/rules.ts
+++ b/lib/chess/src/logic/rules.ts
@@ -103,7 +103,9 @@ function pawnMoves(state: BoardState, from: Square, color: Color, out: Move[]): 
   const fwd = r + dir;
   if (inBounds(fwd, c) && !state.board[sq(fwd, c)]) {
     if (fwd === promoRow) {
-      out.push({ from, to: sq(fwd, c), promotion: 'q' });
+      for (const p of ['q', 'r', 'b', 'n'] as PieceType[]) {
+        out.push({ from, to: sq(fwd, c), promotion: p });
+      }
     } else {
       out.push({ from, to: sq(fwd, c) });
       // Forward 2 from start
@@ -122,7 +124,9 @@ function pawnMoves(state: BoardState, from: Square, color: Color, out: Move[]): 
     const target = state.board[to];
     if (target && target.color !== color) {
       if (fwd === promoRow) {
-        out.push({ from, to, promotion: 'q', captured: target });
+        for (const p of ['q', 'r', 'b', 'n'] as PieceType[]) {
+          out.push({ from, to, promotion: p, captured: target });
+        }
       } else {
         out.push({ from, to, captured: target });
       }

--- a/lib/chess/src/scenes/PlayScene.ts
+++ b/lib/chess/src/scenes/PlayScene.ts
@@ -14,6 +14,7 @@ import {
   applyMove,
   createInitialBoard,
   getLegalMoves,
+  isInsufficientMaterial,
 } from '../logic/rules';
 import { createAI, type ChessAI } from '../logic/ai';
 
@@ -85,6 +86,11 @@ export class PlayScene extends Phaser.Scene {
   private startNewGame() {
     this.clearScheduledCallbacks();
     this.state = createInitialBoard();
+
+    // Initialize clocks from config
+    const initialTime = (this.gameConfig?.timeControl?.initialSeconds ?? 600) * 1000;
+    this.state.clocks = { w: initialTime, b: initialTime };
+
     this.selected = null;
     this.legalForSelected = [];
     this.promotionPrompt = null;
@@ -329,7 +335,6 @@ export class PlayScene extends Phaser.Scene {
         this.legalForSelected = getLegalMoves(this.state, square);
         this.game.events.emit('piece-tapped');
         
-        // Temporarily detach from layer to stay on top
         this.pieceLayer.remove(text);
         this.add.existing(text);
         
@@ -388,6 +393,13 @@ export class PlayScene extends Phaser.Scene {
     } else if (this.state.status === 'draw_material') {
       text = 'Draw - Insufficient Material';
       color = '#EAB308';
+    } else if (this.state.status === 'timeout') {
+      const youWon = this.state.winner === this.playerColor;
+      text = youWon ? 'Time Out - You Win!' : 'Time Out - AI Wins';
+      color = youWon ? '#22C55E' : '#EF4444';
+    } else if (this.state.status === 'draw_timeout') {
+      text = 'Time Out - Draw (Insufficient Material)';
+      color = '#EAB308';
     } else if (this.state.status === 'check') {
       text = this.state.turn === this.playerColor ? 'Check!' : 'AI in Check';
       color = '#F97316';
@@ -406,6 +418,8 @@ export class PlayScene extends Phaser.Scene {
     });
     status.setOrigin(0.5);
     this.uiLayer.add(status);
+
+    this.drawClocks();
 
     if (this.phase === 'game_over') {
       const buttonY = this.boardOriginY + 8 * this.cellSize + 36 * scale;
@@ -430,6 +444,122 @@ export class PlayScene extends Phaser.Scene {
       hitArea.on('pointerdown', () => this.startNewGame());
       this.uiLayer.add(hitArea);
     }
+  }
+
+  private formatTime(ms: number): string {
+    const totalSeconds = Math.max(0, Math.ceil(ms / 1000));
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    
+    if (ms < 10000 && ms > 0) {
+      const tenths = Math.floor((ms % 1000) / 100);
+      return `${totalSeconds - 1}.${tenths}`;
+    }
+    
+    return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+  }
+
+  private drawClocks() {
+    const scale = this.dpr;
+    const width = DEFAULT_WIDTH * scale;
+    const height = DEFAULT_HEIGHT * scale;
+
+    const whiteClockStr = this.formatTime(this.state.clocks.w);
+    const blackClockStr = this.formatTime(this.state.clocks.b);
+
+    const clockWidth = 70 * scale;
+    const clockHeight = 32 * scale;
+    const margin = 10 * scale;
+
+    // AI Clock (Top Right)
+    const aiX = this.boardOriginX + 8 * this.cellSize - clockWidth / 2;
+    const aiY = this.boardOriginY - clockHeight / 2 - 28 * scale;
+    this.drawClock(aiX, aiY, blackClockStr, this.state.turn === 'b');
+
+    // Player Clock (Bottom Right)
+    const pX = this.boardOriginX + 8 * this.cellSize - clockWidth / 2;
+    const pY = this.boardOriginY + 8 * this.cellSize + clockHeight / 2 + 8 * scale;
+    this.drawClock(pX, pY, whiteClockStr, this.state.turn === 'w');
+  }
+
+  private drawClock(x: number, y: number, timeStr: string, isActive: boolean) {
+    const scale = this.dpr;
+    const width = 72 * scale;
+    const height = 30 * scale;
+
+    const bg = this.add.graphics();
+    bg.fillStyle(isActive ? 0xffffff : 0x000000, isActive ? 1 : 0.4);
+    bg.fillRoundedRect(x - width / 2, y - height / 2, width, height, 4 * scale);
+    this.uiLayer.add(bg);
+
+    const text = this.add.text(x, y, timeStr, {
+      fontSize: `${18 * scale}px`,
+      fontFamily: 'monospace',
+      color: isActive ? '#000000' : '#ffffff',
+      fontStyle: 'bold',
+    });
+    text.setOrigin(0.5);
+    this.uiLayer.add(text);
+  }
+
+  update(time: number, delta: number) {
+    if (this.phase === 'game_over') return;
+
+    // Tick the current player's clock
+    this.state.clocks[this.state.turn] -= delta;
+
+    if (this.state.clocks[this.state.turn] <= 0) {
+      this.state.clocks[this.state.turn] = 0;
+      this.handleTimeout();
+    }
+
+    this.drawStatus(); // This includes drawClocks()
+  }
+
+  private handleTimeout() {
+    const turn = this.state.turn;
+    const opponent = turn === 'w' ? 'b' : 'w';
+
+    // FIDE rule: If opponent has no legal sequence to mate, it's a draw.
+    // We simplify by using isInsufficientMaterial.
+    const isOpponentInsufficient = isInsufficientMaterial(this.state.board);
+    
+    if (isOpponentInsufficient) {
+      this.state.status = 'draw_timeout';
+      this.state.winner = 'draw';
+    } else {
+      this.state.status = 'timeout';
+      this.state.winner = opponent;
+    }
+
+    this.handleGameEnd();
+  }
+
+  private executeMove(move: Move) {
+    const isCapture = !!move.captured || !!move.isEnPassant;
+    
+    // Add increment
+    const increment = (this.gameConfig?.timeControl?.incrementSeconds ?? 0) * 1000;
+    this.state.clocks[this.state.turn] += increment;
+
+    this.state = applyMove(this.state, move);
+    this.selected = null;
+    this.legalForSelected = [];
+    this.promotionPrompt = null;
+
+    this.game.events.emit('piece-moved');
+    if (isCapture) this.game.events.emit('piece-captured');
+    if (this.state.status === 'check') this.game.events.emit('check');
+
+    if (this.isTerminal(this.state)) {
+      this.handleGameEnd();
+      return;
+    }
+
+    this.phase = 'ai_turn';
+    this.draw();
+    this.emitState();
+    this.scheduleAI();
   }
 
   private drawPromotionPrompt() {
@@ -503,8 +633,6 @@ export class PlayScene extends Phaser.Scene {
     }
   }
 
-  // ─── Interaction ──────────────────────────────────────
-
   private onSquareTap(square: Square) {
     if (this.phase !== 'player_turn' || this.promotionPrompt) return;
 
@@ -550,28 +678,6 @@ export class PlayScene extends Phaser.Scene {
     this.executeMove(move);
   }
 
-  private executeMove(move: Move) {
-    const isCapture = !!move.captured || !!move.isEnPassant;
-    this.state = applyMove(this.state, move);
-    this.selected = null;
-    this.legalForSelected = [];
-    this.promotionPrompt = null;
-
-    this.game.events.emit('piece-moved');
-    if (isCapture) this.game.events.emit('piece-captured');
-    if (this.state.status === 'check') this.game.events.emit('check');
-
-    if (this.isTerminal(this.state)) {
-      this.handleGameEnd();
-      return;
-    }
-
-    this.phase = 'ai_turn';
-    this.draw();
-    this.emitState();
-    this.scheduleAI();
-  }
-
   private scheduleAI() {
     this.aiMoveTimer?.remove(false);
     this.aiMoveTimer = this.time.delayedCall(400 + Math.random() * 250, () => {
@@ -590,6 +696,11 @@ export class PlayScene extends Phaser.Scene {
     }
 
     const isCapture = !!move.captured || !!move.isEnPassant;
+
+    // Add increment
+    const increment = (this.gameConfig?.timeControl?.incrementSeconds ?? 0) * 1000;
+    this.state.clocks[this.state.turn] += increment;
+
     this.state = applyMove(this.state, move);
 
     this.game.events.emit('piece-moved');

--- a/lib/chess/src/scenes/PlayScene.ts
+++ b/lib/chess/src/scenes/PlayScene.ts
@@ -241,6 +241,15 @@ export class PlayScene extends Phaser.Scene {
     } else if (this.state.status === 'stalemate') {
       text = 'Stalemate - Draw';
       color = '#EAB308';
+    } else if (this.state.status === 'draw_repetition') {
+      text = 'Draw - 3-fold Repetition';
+      color = '#EAB308';
+    } else if (this.state.status === 'draw_50move') {
+      text = 'Draw - 50-Move Rule';
+      color = '#EAB308';
+    } else if (this.state.status === 'draw_material') {
+      text = 'Draw - Insufficient Material';
+      color = '#EAB308';
     } else if (this.state.status === 'check') {
       text = this.state.turn === this.playerColor ? 'Check!' : 'AI in Check';
       color = '#F97316';

--- a/lib/chess/src/scenes/PlayScene.ts
+++ b/lib/chess/src/scenes/PlayScene.ts
@@ -119,6 +119,7 @@ export class PlayScene extends Phaser.Scene {
     this.drawHighlights();
     this.drawPieces();
     this.drawStatus();
+    this.drawMoveHistory();
     this.drawPromotionPrompt();
   }
 
@@ -174,6 +175,34 @@ export class PlayScene extends Phaser.Scene {
         this.boardLayer.add(hitArea);
       }
     }
+  }
+
+  private drawMoveHistory() {
+    const scale = this.dpr;
+    const width = DEFAULT_WIDTH * scale;
+
+    let historyText = '';
+    const history = this.state.history;
+    for (let i = 0; i < history.length; i += 2) {
+      const moveNum = Math.floor(i / 2) + 1;
+      const whiteMove = history[i];
+      const blackMove = history[i + 1] || '';
+      historyText += `${moveNum}. ${whiteMove} ${blackMove}  `;
+    }
+
+    const turns = historyText.trim().split('  ');
+    if (turns.length > 3) {
+      historyText = '... ' + turns.slice(-3).join('  ');
+    }
+
+    const y = this.boardOriginY - 52 * scale;
+    const text = this.add.text(width / 2, y, historyText.trim(), {
+      fontSize: `${13 * scale}px`,
+      fontFamily: 'system-ui, sans-serif',
+      color: '#9CA3AF',
+    });
+    text.setOrigin(0.5);
+    this.uiLayer.add(text);
   }
 
   private drawHighlights() {

--- a/lib/chess/src/scenes/PlayScene.ts
+++ b/lib/chess/src/scenes/PlayScene.ts
@@ -335,6 +335,7 @@ export class PlayScene extends Phaser.Scene {
         this.legalForSelected = getLegalMoves(this.state, square);
         this.game.events.emit('piece-tapped');
         
+        // Temporarily detach from layer to stay on top
         this.pieceLayer.remove(text);
         this.add.existing(text);
         
@@ -400,6 +401,16 @@ export class PlayScene extends Phaser.Scene {
     } else if (this.state.status === 'draw_timeout') {
       text = 'Time Out - Draw (Insufficient Material)';
       color = '#EAB308';
+    } else if (this.state.status === 'resignation') {
+      const youWon = this.state.winner === this.playerColor;
+      text = youWon ? 'AI Resigned - You Win!' : 'You Resigned - AI Wins';
+      color = youWon ? '#22C55E' : '#EF4444';
+    } else if (this.state.status === 'draw_agreement') {
+      text = 'Draw by Agreement';
+      color = '#EAB308';
+    } else if (this.state.status === 'aborted') {
+      text = 'Game Aborted';
+      color = '#9CA3AF';
     } else if (this.state.status === 'check') {
       text = this.state.turn === this.playerColor ? 'Check!' : 'AI in Check';
       color = '#F97316';
@@ -520,8 +531,6 @@ export class PlayScene extends Phaser.Scene {
     const turn = this.state.turn;
     const opponent = turn === 'w' ? 'b' : 'w';
 
-    // FIDE rule: If opponent has no legal sequence to mate, it's a draw.
-    // We simplify by using isInsufficientMaterial.
     const isOpponentInsufficient = isInsufficientMaterial(this.state.board);
     
     if (isOpponentInsufficient) {
@@ -718,17 +727,17 @@ export class PlayScene extends Phaser.Scene {
   }
 
   private isTerminal(state: BoardState): boolean {
-    return state.status === 'checkmate' || state.status.startsWith('draw') || state.status === 'stalemate';
+    return state.status === 'checkmate' || state.status.startsWith('draw') || state.status === 'stalemate' || state.status === 'resignation' || state.status === 'aborted' || state.status === 'timeout';
   }
 
   private handleGameEnd() {
     this.phase = 'game_over';
-    if (this.state.status === 'checkmate') {
-      this.game.events.emit('checkmate');
+    if (this.state.status === 'checkmate' || this.state.status === 'resignation' || this.state.status === 'timeout') {
+      if (this.state.status === 'checkmate') this.game.events.emit('checkmate');
       if (this.state.winner === this.playerColor) this.playerWins++;
       else this.aiWins++;
     } else {
-      this.draws++;
+      if (this.state.status !== 'aborted') this.draws++;
     }
 
     this.draw();
@@ -758,5 +767,47 @@ export class PlayScene extends Phaser.Scene {
 
   private emitState() {
     this.game.events.emit('state-changed', this.state);
+  }
+
+  // ─── Match Control ────────────────────────────────────
+
+  public resign(playerColor: Color) {
+    if (this.phase === 'game_over') return;
+    this.state.status = 'resignation';
+    this.state.winner = playerColor === 'w' ? 'b' : 'w';
+    this.handleGameEnd();
+  }
+
+  public abort() {
+    if (this.phase === 'game_over') return;
+    if (this.state.fullmoveNumber > 1) return;
+    this.state.status = 'aborted';
+    this.state.winner = 'draw';
+    this.handleGameEnd();
+  }
+
+  public offerDraw(): boolean {
+    if (this.phase === 'game_over') return false;
+
+    // AI accepts if the material is equal and it's not a checkmate/check.
+    let wScore = 0;
+    let bScore = 0;
+    const values: Record<PieceType, number> = { p: 1, n: 3, b: 3, r: 5, q: 9, k: 0 };
+    for (const p of this.state.board) {
+      if (!p) continue;
+      if (p.color === 'w') wScore += values[p.type];
+      else bScore += values[p.type];
+    }
+
+    const diff = Math.abs(wScore - bScore);
+    const accepted = diff <= 1 && (this.state.status === 'playing' || this.state.status === 'check');
+
+    if (accepted) {
+      this.state.status = 'draw_agreement';
+      this.state.winner = 'draw';
+      this.handleGameEnd();
+    }
+
+    return accepted;
   }
 }

--- a/lib/chess/src/scenes/PlayScene.ts
+++ b/lib/chess/src/scenes/PlayScene.ts
@@ -116,6 +116,33 @@ export class PlayScene extends Phaser.Scene {
         const x = this.boardOriginX + col * this.cellSize + this.cellSize / 2;
         const y = this.boardOriginY + row * this.cellSize + this.cellSize / 2;
         this.add.rectangle(x, y, this.cellSize, this.cellSize, baseColor);
+
+        // Coordinates
+        const coordColor = isLight ? '#b58863' : '#f0d9b5';
+        const fontSize = Math.floor(10 * scale);
+        const padding = 2 * scale;
+
+        // Rank (1-8) on the left side
+        if (col === 0) {
+          const rank = 8 - row;
+          this.add.text(x - this.cellSize / 2 + padding, y - this.cellSize / 2 + padding, rank.toString(), {
+            fontSize: `${fontSize}px`,
+            fontFamily: 'system-ui, sans-serif',
+            color: coordColor,
+            fontStyle: 'bold',
+          });
+        }
+
+        // File (a-h) on the bottom side
+        if (row === 7) {
+          const file = String.fromCharCode(97 + col);
+          this.add.text(x + this.cellSize / 2 - padding, y + this.cellSize / 2 - padding, file, {
+            fontSize: `${fontSize}px`,
+            fontFamily: 'system-ui, sans-serif',
+            color: coordColor,
+            fontStyle: 'bold',
+          }).setOrigin(1, 1);
+        }
       }
     }
 

--- a/lib/chess/src/scenes/PlayScene.ts
+++ b/lib/chess/src/scenes/PlayScene.ts
@@ -48,18 +48,24 @@ export class PlayScene extends Phaser.Scene {
   private selected: Square | null = null;
   private legalForSelected: Move[] = [];
   private promotionPrompt: PromotionPrompt | null = null;
+  private isDragging = false;
   private playerWins = 0;
   private aiWins = 0;
   private draws = 0;
   private aiMoveTimer: Phaser.Time.TimerEvent | null = null;
   private roundEndTimer: Phaser.Time.TimerEvent | null = null;
 
+  // Persistent layers
+  private boardLayer!: Phaser.GameObjects.Container;
+  private highlightLayer!: Phaser.GameObjects.Container;
+  private pieceLayer!: Phaser.GameObjects.Container;
+  private uiLayer!: Phaser.GameObjects.Container;
+
   constructor() {
     super({ key: 'PlayScene' });
   }
 
   init(data: { stage?: number }): void {
-    // TODO: Use Phaser registry or scene data for better type safety
     this.gameConfig = this.game.registry.get('chessConfig') as GameConfig;
     this.dpr = this.game.registry.get('dpr') || 1;
     this.playerColor = this.gameConfig?.playerColor ?? 'w';
@@ -67,6 +73,11 @@ export class PlayScene extends Phaser.Scene {
   }
 
   create() {
+    this.boardLayer = this.add.container();
+    this.highlightLayer = this.add.container();
+    this.pieceLayer = this.add.container();
+    this.uiLayer = this.add.container();
+
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => this.clearScheduledCallbacks());
     this.startNewGame();
   }
@@ -95,81 +106,102 @@ export class PlayScene extends Phaser.Scene {
   // ─── Drawing ──────────────────────────────────────────
 
   private draw() {
-    this.children.removeAll(true);
-
     const scale = this.dpr;
     const width = DEFAULT_WIDTH * scale;
     const height = DEFAULT_HEIGHT * scale;
-
-    this.add.rectangle(width / 2, height / 2, width, height, BG_COLOR);
 
     const boardSize = Math.min(width - 16 * scale, height - 140 * scale);
     this.cellSize = boardSize / 8;
     this.boardOriginX = (width - boardSize) / 2;
     this.boardOriginY = (height - boardSize) / 2 + 10 * scale;
 
-    // Squares
+    this.drawBoard();
+    this.drawHighlights();
+    this.drawPieces();
+    this.drawStatus();
+    this.drawPromotionPrompt();
+  }
+
+  private drawBoard() {
+    this.boardLayer.removeAll(true);
+    const scale = this.dpr;
+    const width = DEFAULT_WIDTH * scale;
+    const height = DEFAULT_HEIGHT * scale;
+
+    this.boardLayer.add(this.add.rectangle(width / 2, height / 2, width, height, BG_COLOR));
+
     for (let row = 0; row < 8; row++) {
       for (let col = 0; col < 8; col++) {
         const isLight = (row + col) % 2 === 0;
         const baseColor = isLight ? LIGHT_SQUARE : DARK_SQUARE;
         const x = this.boardOriginX + col * this.cellSize + this.cellSize / 2;
         const y = this.boardOriginY + row * this.cellSize + this.cellSize / 2;
-        this.add.rectangle(x, y, this.cellSize, this.cellSize, baseColor);
+        this.boardLayer.add(this.add.rectangle(x, y, this.cellSize, this.cellSize, baseColor));
 
         // Coordinates
         const coordColor = isLight ? '#b58863' : '#f0d9b5';
         const fontSize = Math.floor(10 * scale);
         const padding = 2 * scale;
 
-        // Rank (1-8) on the left side
         if (col === 0) {
-          const rank = 8 - row;
-          this.add.text(x - this.cellSize / 2 + padding, y - this.cellSize / 2 + padding, rank.toString(), {
+          const logicalRow = this.playerColor === 'b' ? 7 - row : row;
+          const rank = 8 - logicalRow;
+          this.boardLayer.add(this.add.text(x - this.cellSize / 2 + padding, y - this.cellSize / 2 + padding, rank.toString(), {
             fontSize: `${fontSize}px`,
             fontFamily: 'system-ui, sans-serif',
             color: coordColor,
             fontStyle: 'bold',
-          });
+          }));
         }
 
-        // File (a-h) on the bottom side
         if (row === 7) {
-          const file = String.fromCharCode(97 + col);
-          this.add.text(x + this.cellSize / 2 - padding, y + this.cellSize / 2 - padding, file, {
+          const logicalCol = this.playerColor === 'b' ? 7 - col : col;
+          const file = String.fromCharCode(97 + logicalCol);
+          this.boardLayer.add(this.add.text(x + this.cellSize / 2 - padding, y + this.cellSize / 2 - padding, file, {
             fontSize: `${fontSize}px`,
             fontFamily: 'system-ui, sans-serif',
             color: coordColor,
             fontStyle: 'bold',
-          }).setOrigin(1, 1);
+          }).setOrigin(1, 1));
         }
+
+        const logicalSq = this.getLogicalSquare(row, col);
+        const hitArea = this.add
+          .rectangle(x, y, this.cellSize, this.cellSize)
+          .setInteractive()
+          .setAlpha(0.001);
+        hitArea.on('pointerdown', () => this.onSquareTap(logicalSq));
+        this.boardLayer.add(hitArea);
+      }
+    }
+  }
+
+  private drawHighlights() {
+    this.highlightLayer.removeAll(true);
+    const scale = this.dpr;
+
+    if (this.state.lastMove) {
+      this.tintSquare(this.state.lastMove.from, LAST_MOVE_TINT, 0.35, this.highlightLayer);
+      this.tintSquare(this.state.lastMove.to, LAST_MOVE_TINT, 0.35, this.highlightLayer);
+    }
+
+    if (this.state.status === 'check') {
+      const kingSq = this.findKingOnBoard(this.state.turn);
+      if (kingSq !== -1) {
+        this.tintSquare(kingSq, 0xef4444, 0.45, this.highlightLayer);
       }
     }
 
-    // Last-move tint
-    if (this.state.lastMove) {
-      this.tintSquare(this.state.lastMove.from, LAST_MOVE_TINT, 0.35);
-      this.tintSquare(this.state.lastMove.to, LAST_MOVE_TINT, 0.35);
-    }
-
-    // Selected highlight
     if (this.selected !== null) {
-      this.tintSquare(this.selected, SELECTED_SQUARE, 0.55);
+      this.tintSquare(this.selected, SELECTED_SQUARE, 0.55, this.highlightLayer);
     }
 
-    // Pieces
-    for (let index = 0; index < 64; index++) {
-      const piece = this.state.board[index];
-      if (piece) this.drawPiece(index, piece);
-    }
-
-    // Legal-move dots
     const markerKeys = new Set<string>();
     for (const move of this.legalForSelected) {
       const markerKey = `${move.to}:${move.captured ? 'capture' : move.isEnPassant ? 'capture' : 'quiet'}`;
       if (markerKeys.has(markerKey)) continue;
       markerKeys.add(markerKey);
-      
+
       const { cx, cy } = this.squareCenter(move.to);
       const isCapture = !!move.captured || !!move.isEnPassant;
       const marker = this.add.graphics();
@@ -180,35 +212,66 @@ export class PlayScene extends Phaser.Scene {
         marker.fillStyle(LEGAL_DOT_COLOR, 0.55);
         marker.fillCircle(cx, cy, this.cellSize * 0.14);
       }
+      this.highlightLayer.add(marker);
     }
-
-    if (this.phase === 'player_turn' && !this.promotionPrompt) {
-      for (let index = 0; index < 64; index++) {
-        const { cx, cy } = this.squareCenter(index);
-        const hitArea = this.add
-          .rectangle(cx, cy, this.cellSize, this.cellSize)
-          .setInteractive()
-          .setAlpha(0.001);
-        hitArea.on('pointerdown', () => this.onSquareTap(index));
-      }
-    }
-
-    this.drawStatus();
-    this.drawPromotionPrompt();
   }
 
-  private tintSquare(square: Square, color: number, alpha: number) {
+  private drawPieces() {
+    this.pieceLayer.removeAll(true);
+    for (let i = 0; i < 64; i++) {
+      const piece = this.state.board[i];
+      if (piece) {
+        if (this.isDragging && this.selected === i) continue;
+        this.drawPiece(i, piece);
+      }
+    }
+  }
+
+  private findKingOnBoard(color: Color): Square {
+    for (let i = 0; i < 64; i++) {
+      const p = this.state.board[i];
+      if (p && p.type === 'k' && p.color === color) return i;
+    }
+    return -1;
+  }
+
+  private tintSquare(square: Square, color: number, alpha: number, container: Phaser.GameObjects.Container) {
     const { cx, cy } = this.squareCenter(square);
-    this.add.rectangle(cx, cy, this.cellSize, this.cellSize, color, alpha);
+    container.add(this.add.rectangle(cx, cy, this.cellSize, this.cellSize, color, alpha));
+  }
+
+  private getLogicalSquare(drawRow: number, drawCol: number): Square {
+    const row = this.playerColor === 'b' ? 7 - drawRow : drawRow;
+    const col = this.playerColor === 'b' ? 7 - drawCol : drawCol;
+    return (row << 3) | col;
   }
 
   private squareCenter(square: Square): { cx: number; cy: number } {
-    const row = square >> 3;
-    const col = square & 7;
+    const { drawRow, drawCol } = this.getDrawPos(square);
     return {
-      cx: this.boardOriginX + col * this.cellSize + this.cellSize / 2,
-      cy: this.boardOriginY + row * this.cellSize + this.cellSize / 2,
+      cx: this.boardOriginX + drawCol * this.cellSize + this.cellSize / 2,
+      cy: this.boardOriginY + drawRow * this.cellSize + this.cellSize / 2,
     };
+  }
+
+  private getDrawPos(square: Square): { drawRow: number; drawCol: number } {
+    let row = square >> 3;
+    let col = square & 7;
+    if (this.playerColor === 'b') {
+      row = 7 - row;
+      col = 7 - col;
+    }
+    return { drawRow: row, drawCol: col };
+  }
+
+  private getSquareFromPointer(x: number, y: number): Square | null {
+    const col = Math.floor((x - this.boardOriginX) / this.cellSize);
+    const row = Math.floor((y - this.boardOriginY) / this.cellSize);
+    if (col < 0 || col >= 8 || row < 0 || row >= 8) return null;
+
+    const logicalRow = this.playerColor === 'b' ? 7 - row : row;
+    const logicalCol = this.playerColor === 'b' ? 7 - col : col;
+    return (logicalRow << 3) | logicalCol;
   }
 
   private drawPiece(square: Square, piece: Piece) {
@@ -225,9 +288,55 @@ export class PlayScene extends Phaser.Scene {
       strokeThickness: Math.max(1, Math.floor(this.cellSize * 0.025)),
     });
     text.setOrigin(0.5, 0.55);
+    this.pieceLayer.add(text);
+
+    if (this.phase === 'player_turn' && !this.promotionPrompt && piece.color === this.playerColor) {
+      text.setInteractive({ draggable: true });
+      this.input.setDraggable(text);
+
+      text.on('dragstart', () => {
+        this.isDragging = true;
+        this.selected = square;
+        this.legalForSelected = getLegalMoves(this.state, square);
+        this.game.events.emit('piece-tapped');
+        
+        // Temporarily detach from layer to stay on top
+        this.pieceLayer.remove(text);
+        this.add.existing(text);
+        
+        this.drawHighlights();
+        this.drawPieces();
+      });
+
+      text.on('drag', (pointer: Phaser.Input.Pointer, dragX: number, dragY: number) => {
+        text.x = dragX;
+        text.y = dragY;
+      });
+
+      text.on('dragend', (pointer: Phaser.Input.Pointer) => {
+        this.isDragging = false;
+        const targetSq = this.getSquareFromPointer(pointer.x, pointer.y);
+        if (targetSq !== null) {
+          const move = this.legalForSelected.find((m) => m.to === targetSq);
+          if (move) {
+            text.destroy();
+            if (move.promotion) {
+              this.promotionPrompt = { moves: this.legalForSelected.filter(m => m.to === targetSq) };
+              this.draw();
+              return;
+            }
+            this.executeMove(move);
+            return;
+          }
+        }
+        text.destroy();
+        this.draw();
+      });
+    }
   }
 
   private drawStatus() {
+    this.uiLayer.removeAll(true);
     const scale = this.dpr;
     const width = DEFAULT_WIDTH * scale;
 
@@ -267,12 +376,14 @@ export class PlayScene extends Phaser.Scene {
       fontStyle: 'bold',
     });
     status.setOrigin(0.5);
+    this.uiLayer.add(status);
 
     if (this.phase === 'game_over') {
       const buttonY = this.boardOriginY + 8 * this.cellSize + 36 * scale;
       const button = this.add.graphics();
       button.fillStyle(0x2563eb, 1);
       button.fillRoundedRect(width / 2 - 80 * scale, buttonY - 22 * scale, 160 * scale, 44 * scale, 12 * scale);
+      this.uiLayer.add(button);
 
       const buttonText = this.add.text(width / 2, buttonY, 'Play Again', {
         fontSize: `${16 * scale}px`,
@@ -281,12 +392,14 @@ export class PlayScene extends Phaser.Scene {
         fontStyle: 'bold',
       });
       buttonText.setOrigin(0.5);
+      this.uiLayer.add(buttonText);
 
       const hitArea = this.add
         .rectangle(width / 2, buttonY, 160 * scale, 44 * scale)
         .setInteractive()
         .setAlpha(0.001);
       hitArea.on('pointerdown', () => this.startNewGame());
+      this.uiLayer.add(hitArea);
     }
   }
 
@@ -310,12 +423,14 @@ export class PlayScene extends Phaser.Scene {
       this.promotionPrompt = null;
       this.draw();
     });
+    this.uiLayer.add(backdrop);
 
     const panel = this.add.graphics();
     panel.fillStyle(0x111827, 0.98);
     panel.fillRoundedRect(panelX, panelY, panelWidth, panelHeight, 16 * scale);
     panel.lineStyle(2 * scale, 0xf9fafb, 0.12);
     panel.strokeRoundedRect(panelX, panelY, panelWidth, panelHeight, 16 * scale);
+    this.uiLayer.add(panel);
 
     const title = this.add.text(width / 2, panelY + 22 * scale, 'Choose Promotion', {
       fontSize: `${16 * scale}px`,
@@ -324,6 +439,7 @@ export class PlayScene extends Phaser.Scene {
       fontStyle: 'bold',
     });
     title.setOrigin(0.5);
+    this.uiLayer.add(title);
 
     for (let index = 0; index < options.length; index++) {
       const pieceType = options[index];
@@ -336,6 +452,7 @@ export class PlayScene extends Phaser.Scene {
       const button = this.add.graphics();
       button.fillStyle(0xf9fafb, 1);
       button.fillRoundedRect(buttonX, buttonY, optionWidth - 16 * scale, optionHeight, 12 * scale);
+      this.uiLayer.add(button);
 
       const glyph = PIECE_GLYPH[`${this.playerColor}${pieceType}`];
       const pieceText = this.add.text(centerX, centerY, glyph, {
@@ -346,12 +463,14 @@ export class PlayScene extends Phaser.Scene {
         strokeThickness: Math.max(1, Math.floor(this.cellSize * 0.02)),
       });
       pieceText.setOrigin(0.5, 0.55);
+      this.uiLayer.add(pieceText);
 
       const hitArea = this.add
         .rectangle(centerX, centerY, optionWidth - 16 * scale, optionHeight)
         .setInteractive()
         .setAlpha(0.001);
       hitArea.on('pointerdown', () => this.confirmPromotion(pieceType));
+      this.uiLayer.add(hitArea);
     }
   }
 
@@ -379,14 +498,14 @@ export class PlayScene extends Phaser.Scene {
       this.selected = square;
       this.legalForSelected = getLegalMoves(this.state, square);
       this.game.events.emit('piece-tapped');
-      this.draw();
+      this.drawHighlights();
       return;
     }
 
     if (this.selected !== null) {
       this.selected = null;
       this.legalForSelected = [];
-      this.draw();
+      this.drawHighlights();
     }
   }
 
@@ -459,7 +578,7 @@ export class PlayScene extends Phaser.Scene {
   }
 
   private isTerminal(state: BoardState): boolean {
-    return state.status === 'checkmate' || state.status === 'stalemate';
+    return state.status === 'checkmate' || state.status.startsWith('draw') || state.status === 'stalemate';
   }
 
   private handleGameEnd() {
@@ -497,37 +616,7 @@ export class PlayScene extends Phaser.Scene {
     });
   }
 
-  // ─── Events ───────────────────────────────────────────
-
   private emitState() {
-    const { whiteMaterial, blackMaterial } = this.computeMaterial();
-    this.game.events.emit('score-update', {
-      turn: this.state.turn,
-      status: this.state.status,
-      playerWins: this.playerWins,
-      aiWins: this.aiWins,
-      draws: this.draws,
-      whiteMaterial,
-      blackMaterial,
-    });
-  }
-
-  private computeMaterial(): { whiteMaterial: number; blackMaterial: number } {
-    const value: Record<string, number> = { p: 1, n: 3, b: 3, r: 5, q: 9, k: 0 };
-    let whiteMaterial = 0;
-    let blackMaterial = 0;
-
-    for (const piece of this.state.board) {
-      if (!piece) continue;
-      if (piece.color === 'w') whiteMaterial += value[piece.type];
-      else blackMaterial += value[piece.type];
-    }
-
-    return { whiteMaterial, blackMaterial };
-  }
-
-  shutdown(): void {
-    this.clearScheduledCallbacks();
-    this.tweens.killAll();
+    this.game.events.emit('state-changed', this.state);
   }
 }

--- a/lib/chess/src/types.ts
+++ b/lib/chess/src/types.ts
@@ -39,7 +39,10 @@ export type GameStatus =
   | 'draw_50move'
   | 'draw_material'
   | 'timeout'
-  | 'draw_timeout';
+  | 'draw_timeout'
+  | 'resignation'
+  | 'draw_agreement'
+  | 'aborted';
 
 export interface BoardState {
   board: (Piece | null)[]; // length 64

--- a/lib/chess/src/types.ts
+++ b/lib/chess/src/types.ts
@@ -30,7 +30,14 @@ export interface CastlingRights {
   bq: boolean;
 }
 
-export type GameStatus = 'playing' | 'check' | 'checkmate' | 'stalemate' | 'draw';
+export type GameStatus =
+  | 'playing'
+  | 'check'
+  | 'checkmate'
+  | 'stalemate'
+  | 'draw_repetition'
+  | 'draw_50move'
+  | 'draw_material';
 
 export interface BoardState {
   board: (Piece | null)[]; // length 64
@@ -42,6 +49,7 @@ export interface BoardState {
   status: GameStatus;
   winner: Color | 'draw' | null;
   lastMove: Move | null;
+  positionHistory: Record<string, number>; // hash -> count for 3-fold repetition
 }
 
 export type Difficulty = 'easy' | 'medium' | 'hard';

--- a/lib/chess/src/types.ts
+++ b/lib/chess/src/types.ts
@@ -37,7 +37,9 @@ export type GameStatus =
   | 'stalemate'
   | 'draw_repetition'
   | 'draw_50move'
-  | 'draw_material';
+  | 'draw_material'
+  | 'timeout'
+  | 'draw_timeout';
 
 export interface BoardState {
   board: (Piece | null)[]; // length 64
@@ -51,6 +53,7 @@ export interface BoardState {
   lastMove: Move | null;
   positionHistory: Record<string, number>; // hash -> count for 3-fold repetition
   history: string[]; // SAN strings
+  clocks: { w: number; b: number }; // remaining milliseconds
 }
 
 export type Difficulty = 'easy' | 'medium' | 'hard';
@@ -58,4 +61,8 @@ export type Difficulty = 'easy' | 'medium' | 'hard';
 export interface GameConfig {
   difficulty?: Difficulty;
   playerColor?: Color; // MVP: always 'w'
+  timeControl?: {
+    initialSeconds: number;
+    incrementSeconds: number;
+  };
 }

--- a/lib/chess/src/types.ts
+++ b/lib/chess/src/types.ts
@@ -50,6 +50,7 @@ export interface BoardState {
   winner: Color | 'draw' | null;
   lastMove: Move | null;
   positionHistory: Record<string, number>; // hash -> count for 3-fold repetition
+  history: string[]; // SAN strings
 }
 
 export type Difficulty = 'easy' | 'medium' | 'hard';

--- a/web/arcade/src/games/chess/Board.tsx
+++ b/web/arcade/src/games/chess/Board.tsx
@@ -1,0 +1,184 @@
+import React from 'react';
+import { styled } from '../../styles/stitches.config';
+import type { BoardState, Square, Move, PieceType, Piece } from '@arcade/lib-chess';
+
+const BoardContainer = styled('div', {
+  width: '100%',
+  aspectRatio: '1/1',
+  display: 'grid',
+  gridTemplateColumns: 'repeat(8, 1fr)',
+  gridTemplateRows: 'repeat(8, 1fr)',
+  border: '4px solid #312e2b',
+  borderRadius: 4,
+  overflow: 'hidden',
+  userSelect: 'none',
+  touchAction: 'none',
+});
+
+const SquareUI = styled('div', {
+  position: 'relative',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  fontSize: 'min(8vw, 40px)',
+  cursor: 'pointer',
+  transition: 'background-color 0.1s ease',
+  
+  variants: {
+    color: {
+      light: { backgroundColor: '#f0d9b5' },
+      dark: { backgroundColor: '#b58863' },
+    },
+    isSelected: {
+      true: { backgroundColor: '#f7ec74 !important' },
+    },
+    isLastMove: {
+      true: { backgroundColor: 'rgba(247, 236, 116, 0.6)' },
+    }
+  }
+});
+
+const LegalDot = styled('div', {
+  width: '25%',
+  height: '25%',
+  borderRadius: '50%',
+  backgroundColor: 'rgba(0, 0, 0, 0.15)',
+  pointerEvents: 'none',
+  variants: {
+    isCapture: {
+      true: {
+        width: '80%',
+        height: '80%',
+        borderRadius: '50%',
+        border: '4px solid rgba(0, 0, 0, 0.1)',
+        backgroundColor: 'transparent',
+      }
+    }
+  }
+});
+
+const PieceUI = styled('div', {
+  zIndex: 1,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '100%',
+  height: '100%',
+  fontFamily: '"Segoe UI Symbol", "Apple Color Emoji", "Noto Sans Symbols2", system-ui, sans-serif',
+});
+
+const PromotionOverlay = styled('div', {
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  backgroundColor: 'rgba(0, 0, 0, 0.5)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 10,
+});
+
+const PromotionMenu = styled('div', {
+  backgroundColor: '#fff',
+  borderRadius: 12,
+  padding: 12,
+  display: 'flex',
+  gap: 8,
+  boxShadow: '0 10px 25px rgba(0,0,0,0.3)',
+});
+
+const PromotionItem = styled('button', {
+  width: 60,
+  height: 60,
+  fontSize: 32,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  border: '2px solid #E5E7EB',
+  borderRadius: 8,
+  backgroundColor: '#fff',
+  cursor: 'pointer',
+  '&:hover': {
+    backgroundColor: '#F3F4F6',
+    borderColor: '#2563EB',
+  }
+});
+
+const PIECE_GLYPH: Record<string, string> = {
+  wk: '♔', wq: '♕', wr: '♖', wb: '♗', wn: '♘', wp: '♙',
+  bk: '♚', bq: '♛', br: '♜', bb: '♝', bn: '♞', bp: '♟',
+};
+
+interface BoardProps {
+  state: BoardState;
+  selectedSquare: Square | null;
+  legalMoves: Move[];
+  promotionMove: Move | null;
+  onSquareClick: (square: Square) => void;
+  onSelectPromotion: (type: PieceType) => void;
+  onCancelPromotion: () => void;
+}
+
+export const Board: React.FC<BoardProps> = ({
+  state,
+  selectedSquare,
+  legalMoves,
+  promotionMove,
+  onSquareClick,
+  onSelectPromotion,
+  onCancelPromotion,
+}) => {
+  const squares = Array.from({ length: 64 }, (_, i) => i);
+
+  return (
+    <div style={{ position: 'relative', width: '100%', maxWidth: 500, margin: '0 auto' }}>
+      <BoardContainer>
+        {squares.map((index) => {
+          const row = Math.floor(index / 8);
+          const col = index % 8;
+          const isLight = (row + col) % 2 === 0;
+          const piece = state.board[index];
+          const isSelected = selectedSquare === index;
+          const legalMove = legalMoves.find(m => m.to === index);
+          const isLastMove = state.lastMove?.from === index || state.lastMove?.to === index;
+
+          return (
+            <SquareUI
+              key={index}
+              color={isLight ? 'light' : 'dark'}
+              isSelected={isSelected}
+              isLastMove={isLastMove}
+              onClick={() => onSquareClick(index)}
+            >
+              {piece && (
+                <PieceUI style={{ 
+                  color: piece.color === 'w' ? '#fff' : '#000',
+                  textShadow: piece.color === 'w' ? '0 0 2px #000' : '0 0 2px #fff'
+                }}>
+                  {PIECE_GLYPH[`${piece.color}${piece.type}`]}
+                </PieceUI>
+              )}
+              {legalMove && (
+                <LegalDot isCapture={!!legalMove.captured || !!legalMove.isEnPassant} />
+              )}
+            </SquareUI>
+          );
+        })}
+      </BoardContainer>
+
+      {promotionMove && (
+        <PromotionOverlay onClick={onCancelPromotion}>
+          <PromotionMenu onClick={(e) => e.stopPropagation()}>
+            {(['q', 'r', 'b', 'n'] as PieceType[]).map((type) => (
+              <PromotionItem key={type} onClick={() => onSelectPromotion(type)}>
+                {PIECE_GLYPH[`w${type}`]}
+              </PromotionItem>
+            ))}
+          </PromotionMenu>
+        </PromotionOverlay>
+      )}
+    </div>
+  );
+};

--- a/web/arcade/src/games/chess/HUD.tsx
+++ b/web/arcade/src/games/chess/HUD.tsx
@@ -51,7 +51,15 @@ interface HUDProps {
 
 function statusLabel(status: GameStatus, turn: Color): { text: string; color: string } {
   if (status === 'checkmate') return { text: 'Checkmate', color: '#EF4444' };
-  if (status === 'stalemate') return { text: 'Stalemate', color: '#EAB308' };
+  if (status === 'stalemate') return { text: 'Stalemate - Draw', color: '#EAB308' };
+  if (status === 'draw_repetition') return { text: '3-fold Repetition - Draw', color: '#EAB308' };
+  if (status === 'draw_50move') return { text: '50-Move Rule - Draw', color: '#EAB308' };
+  if (status === 'draw_material') return { text: 'Insufficient Material - Draw', color: '#EAB308' };
+  if (status === 'timeout') return { text: 'Time Out', color: '#EF4444' };
+  if (status === 'draw_timeout') return { text: 'Time Out - Draw', color: '#EAB308' };
+  if (status === 'resignation') return { text: 'Resigned', color: '#EF4444' };
+  if (status === 'draw_agreement') return { text: 'Draw by Agreement', color: '#EAB308' };
+  if (status === 'aborted') return { text: 'Game Aborted', color: '#9CA3AF' };
   if (status === 'check') return { text: 'Check!', color: '#F97316' };
   return { text: turn === 'w' ? 'Your turn' : 'AI thinking…', color: '#6B7280' };
 }

--- a/web/arcade/src/games/chess/routes.tsx
+++ b/web/arcade/src/games/chess/routes.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { GameCanvas } from '../../components/GameCanvas';
 import { GameHomeLayout } from '../../components/GameHomeLayout';
 import { PlayLayout } from '../../components/PlayLayout';
 import { registerRoutes } from '../../router';
 import { HUD as ChessHUD } from './HUD';
 import { useGame as useChessGame } from './useGame';
 import type { Difficulty } from '@arcade/lib-chess';
+import { Board } from './Board';
 
 const DIFFICULTY_OPTIONS: { value: Difficulty; label: string; desc: string }[] = [
   { value: 'easy', label: 'Easy', desc: 'Beginner' },
@@ -63,8 +63,23 @@ function ChessHomeRoute() {
 function ChessPlayRoute() {
   const [params] = useSearchParams();
   const difficulty = parseDifficulty(params.get('difficulty'));
-  const { containerRef, turn, status, playerWins, aiWins, draws, whiteMaterial, blackMaterial } =
-    useChessGame({ difficulty });
+  const { 
+    state, 
+    turn, 
+    status, 
+    playerWins, 
+    aiWins, 
+    draws, 
+    whiteMaterial, 
+    blackMaterial,
+    selectedSquare,
+    legalMoves,
+    promotionMove,
+    handleSquareClick,
+    handlePromotion,
+    cancelPromotion
+  } = useChessGame({ difficulty });
+
   return (
     <PlayLayout>
       <ChessHUD
@@ -76,7 +91,17 @@ function ChessPlayRoute() {
         whiteMaterial={whiteMaterial}
         blackMaterial={blackMaterial}
       />
-      <GameCanvas ref={containerRef} />
+      <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 16 }}>
+        <Board 
+          state={state}
+          selectedSquare={selectedSquare}
+          legalMoves={legalMoves}
+          promotionMove={promotionMove}
+          onSquareClick={handleSquareClick}
+          onSelectPromotion={handlePromotion}
+          onCancelPromotion={cancelPromotion}
+        />
+      </div>
     </PlayLayout>
   );
 }

--- a/web/arcade/src/games/chess/routes.tsx
+++ b/web/arcade/src/games/chess/routes.tsx
@@ -77,8 +77,13 @@ function ChessPlayRoute() {
     promotionMove,
     handleSquareClick,
     handlePromotion,
-    cancelPromotion
+    cancelPromotion,
+    resign,
+    abort,
+    offerDraw
   } = useChessGame({ difficulty });
+
+  const isGameOver = ['checkmate', 'stalemate', 'draw_repetition', 'draw_50move', 'draw_material', 'timeout', 'draw_timeout', 'resignation', 'draw_agreement', 'aborted'].includes(state.status);
 
   return (
     <PlayLayout>
@@ -91,7 +96,7 @@ function ChessPlayRoute() {
         whiteMaterial={whiteMaterial}
         blackMaterial={blackMaterial}
       />
-      <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 16 }}>
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: 16, gap: 16 }}>
         <Board 
           state={state}
           selectedSquare={selectedSquare}
@@ -101,6 +106,36 @@ function ChessPlayRoute() {
           onSelectPromotion={handlePromotion}
           onCancelPromotion={cancelPromotion}
         />
+        
+        {!isGameOver && (
+          <div style={{ display: 'flex', gap: 8, width: '100%', maxWidth: 500 }}>
+            {state.fullmoveNumber === 1 && (
+              <button 
+                onClick={abort}
+                style={{ flex: 1, padding: '10px', borderRadius: 8, border: '1px solid #E5E7EB', backgroundColor: '#fff', fontSize: 13, fontWeight: 600, cursor: 'pointer' }}
+              >
+                Abort
+              </button>
+            )}
+            <button 
+              onClick={() => {
+                if (offerDraw()) alert('AI accepted the draw!');
+                else alert('AI declined the draw.');
+              }}
+              style={{ flex: 1, padding: '10px', borderRadius: 8, border: '1px solid #E5E7EB', backgroundColor: '#fff', fontSize: 13, fontWeight: 600, cursor: 'pointer' }}
+            >
+              Offer Draw
+            </button>
+            <button 
+              onClick={() => {
+                if (confirm('Are you sure you want to resign?')) resign();
+              }}
+              style={{ flex: 1, padding: '10px', borderRadius: 8, border: '1px solid #fee2e2', backgroundColor: '#fff', color: '#dc2626', fontSize: 13, fontWeight: 600, cursor: 'pointer' }}
+            >
+              Resign
+            </button>
+          </div>
+        )}
       </div>
     </PlayLayout>
   );

--- a/web/arcade/src/games/chess/useGame.ts
+++ b/web/arcade/src/games/chess/useGame.ts
@@ -44,6 +44,35 @@ export function useGame({ difficulty = 'medium' }: UseGameOptions) {
     setPromotionMove(null);
   }, []);
 
+  const resign = useCallback(() => {
+    setState(prev => ({ ...prev, status: 'resignation' as GameStatus, winner: 'b' as Color }));
+  }, []);
+
+  const abort = useCallback(() => {
+    setState(prev => {
+      if (prev.fullmoveNumber > 1) return prev;
+      return { ...prev, status: 'aborted' as GameStatus, winner: 'draw' as Color | 'draw' };
+    });
+  }, []);
+
+  const offerDraw = useCallback(() => {
+    // Simplified draw acceptance logic: AI accepts if material is equal
+    const values: Record<string, number> = { p: 1, n: 3, b: 3, r: 5, q: 9, k: 0 };
+    let w = 0, b = 0;
+    state.board.forEach(p => {
+      if (p) {
+        if (p.color === 'w') w += values[p.type];
+        else b += values[p.type];
+      }
+    });
+    
+    if (Math.abs(w - b) <= 1) {
+      setState(prev => ({ ...prev, status: 'draw_agreement' as GameStatus, winner: 'draw' as Color | 'draw' }));
+      return true;
+    }
+    return false;
+  }, [state.board]);
+
   const executeMove = useCallback((move: Move) => {
     setState(prev => {
       const isCapture = !!move.captured || !!move.isEnPassant;
@@ -62,7 +91,8 @@ export function useGame({ difficulty = 'medium' }: UseGameOptions) {
   }, []);
 
   const handleSquareClick = useCallback((square: Square) => {
-    if (state.turn !== 'w' || state.status === 'checkmate' || state.status === 'stalemate') return;
+    const terminal = ['checkmate', 'stalemate', 'draw_repetition', 'draw_50move', 'draw_material', 'timeout', 'draw_timeout', 'resignation', 'draw_agreement', 'aborted'];
+    if (state.turn !== 'w' || terminal.includes(state.status)) return;
 
     // If a move is selected
     const move = legalMoves.find(m => m.to === square);
@@ -95,7 +125,8 @@ export function useGame({ difficulty = 'medium' }: UseGameOptions) {
 
   // AI Turn
   useEffect(() => {
-    if (state.turn === 'b' && state.status !== 'checkmate' && state.status !== 'stalemate') {
+    const terminal = ['checkmate', 'stalemate', 'draw_repetition', 'draw_50move', 'draw_material', 'timeout', 'draw_timeout', 'resignation', 'draw_agreement', 'aborted'];
+    if (state.turn === 'b' && !terminal.includes(state.status)) {
       aiTimerRef.current = setTimeout(() => {
         const move = aiRef.current.selectMove(state);
         if (move) {
@@ -110,12 +141,15 @@ export function useGame({ difficulty = 'medium' }: UseGameOptions) {
 
   // Game End Logic
   useEffect(() => {
-    if (state.status === 'checkmate' || state.status === 'stalemate') {
-      const winner = state.status === 'checkmate' ? (state.winner === 'w' ? 'player' : 'ai') : 'draw';
+    const terminal = ['checkmate', 'stalemate', 'draw_repetition', 'draw_50move', 'draw_material', 'timeout', 'draw_timeout', 'resignation', 'draw_agreement', 'aborted'];
+    if (terminal.includes(state.status)) {
+      const winner = (state.status === 'checkmate' || state.status === 'timeout' || state.status === 'resignation') 
+        ? (state.winner === 'w' ? 'player' : 'ai') 
+        : 'draw';
       
       if (winner === 'player') setPlayerWins(prev => prev + 1);
       else if (winner === 'ai') setAiWins(prev => prev + 1);
-      else setDraws(prev => prev + 1);
+      else if (state.status !== 'aborted') setDraws(prev => prev + 1);
 
       stageComplete({
         stage: 0,
@@ -156,6 +190,9 @@ export function useGame({ difficulty = 'medium' }: UseGameOptions) {
     handleSquareClick,
     handlePromotion,
     resetGame,
+    resign,
+    abort,
+    offerDraw,
     cancelPromotion: () => setPromotionMove(null),
   };
 }

--- a/web/arcade/src/games/chess/useGame.ts
+++ b/web/arcade/src/games/chess/useGame.ts
@@ -1,5 +1,17 @@
-import { useRef, useEffect, useState } from 'react';
-import { createGame, destroyGame, type Color, type Difficulty, type GameStatus } from '@arcade/lib-chess';
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { 
+  createInitialBoard, 
+  getLegalMoves, 
+  applyMove, 
+  createAI,
+  type Color, 
+  type Difficulty, 
+  type GameStatus, 
+  type BoardState,
+  type Move,
+  type Square,
+  type PieceType
+} from '@arcade/lib-chess';
 import { stageComplete, haptic } from '../../utils/bridge';
 
 export interface RoundResult {
@@ -9,72 +21,141 @@ export interface RoundResult {
   draws: number;
 }
 
-interface ScoreUpdate {
-  turn: Color;
-  status: GameStatus;
-  playerWins: number;
-  aiWins: number;
-  draws: number;
-  whiteMaterial: number;
-  blackMaterial: number;
-}
-
 interface UseGameOptions {
   difficulty?: Difficulty;
 }
 
 export function useGame({ difficulty = 'medium' }: UseGameOptions) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [turn, setTurn] = useState<Color>('w');
-  const [status, setStatus] = useState<GameStatus>('playing');
+  const [state, setState] = useState<BoardState>(createInitialBoard());
   const [playerWins, setPlayerWins] = useState(0);
   const [aiWins, setAiWins] = useState(0);
   const [draws, setDraws] = useState(0);
-  const [whiteMaterial, setWhiteMaterial] = useState(39);
-  const [blackMaterial, setBlackMaterial] = useState(39);
+  const [selectedSquare, setSelectedSquare] = useState<Square | null>(null);
+  const [legalMoves, setLegalMoves] = useState<Move[]>([]);
+  const [promotionMove, setPromotionMove] = useState<Move | null>(null);
+  
+  const aiRef = useRef(createAI(difficulty));
+  const aiTimerRef = useRef<NodeJS.Timeout | null>(null);
 
-  useEffect(() => {
-    if (!containerRef.current) return;
+  const resetGame = useCallback(() => {
+    setState(createInitialBoard());
+    setSelectedSquare(null);
+    setLegalMoves([]);
+    setPromotionMove(null);
+  }, []);
 
-    const game = createGame(containerRef.current, { difficulty });
-
-    game.events.on('piece-tapped', () => haptic('chess-piece-tapped'));
-    game.events.on('piece-moved', () => haptic('chess-piece-moved'));
-    game.events.on('piece-captured', () => haptic('chess-capture'));
-    game.events.on('check', () => haptic('chess-check'));
-    game.events.on('checkmate', () => haptic('chess-checkmate'));
-
-    game.events.on('score-update', (data: ScoreUpdate) => {
-      setTurn(data.turn);
-      setStatus(data.status);
-      setPlayerWins(data.playerWins);
-      setAiWins(data.aiWins);
-      setDraws(data.draws);
-      setWhiteMaterial(data.whiteMaterial);
-      setBlackMaterial(data.blackMaterial);
+  const executeMove = useCallback((move: Move) => {
+    setState(prev => {
+      const isCapture = !!move.captured || !!move.isEnPassant;
+      const nextState = applyMove(prev, move);
+      
+      haptic('chess-piece-moved');
+      if (isCapture) haptic('chess-capture');
+      if (nextState.status === 'check') haptic('chess-check');
+      if (nextState.status === 'checkmate') haptic('chess-checkmate');
+      
+      return nextState;
     });
+    setSelectedSquare(null);
+    setLegalMoves([]);
+    setPromotionMove(null);
+  }, []);
 
-    game.events.on('round-end', (data: RoundResult) => {
+  const handleSquareClick = useCallback((square: Square) => {
+    if (state.turn !== 'w' || state.status === 'checkmate' || state.status === 'stalemate') return;
+
+    // If a move is selected
+    const move = legalMoves.find(m => m.to === square);
+    if (move) {
+      if (move.promotion) {
+        setPromotionMove(move);
+        return;
+      }
+      executeMove(move);
+      return;
+    }
+
+    // Select piece
+    const piece = state.board[square];
+    if (piece && piece.color === 'w') {
+      setSelectedSquare(square);
+      setLegalMoves(getLegalMoves(state, square));
+      haptic('chess-piece-tapped');
+    } else {
+      setSelectedSquare(null);
+      setLegalMoves([]);
+    }
+  }, [state, legalMoves, executeMove]);
+
+  const handlePromotion = useCallback((type: PieceType) => {
+    if (promotionMove) {
+      executeMove({ ...promotionMove, promotion: type });
+    }
+  }, [promotionMove, executeMove]);
+
+  // AI Turn
+  useEffect(() => {
+    if (state.turn === 'b' && state.status !== 'checkmate' && state.status !== 'stalemate') {
+      aiTimerRef.current = setTimeout(() => {
+        const move = aiRef.current.selectMove(state);
+        if (move) {
+          executeMove(move);
+        }
+      }, 600);
+    }
+    return () => {
+      if (aiTimerRef.current) clearTimeout(aiTimerRef.current);
+    };
+  }, [state, executeMove]);
+
+  // Game End Logic
+  useEffect(() => {
+    if (state.status === 'checkmate' || state.status === 'stalemate') {
+      const winner = state.status === 'checkmate' ? (state.winner === 'w' ? 'player' : 'ai') : 'draw';
+      
+      if (winner === 'player') setPlayerWins(prev => prev + 1);
+      else if (winner === 'ai') setAiWins(prev => prev + 1);
+      else setDraws(prev => prev + 1);
+
       stageComplete({
         stage: 0,
-        score: data.playerWins,
-        cleared: data.winner === 'player',
+        score: playerWins + (winner === 'player' ? 1 : 0),
+        cleared: winner === 'player',
       });
-    });
+    }
+  }, [state.status, state.winner]);
 
-    return () => {
-      destroyGame(game);
-    };
-  }, [difficulty]);
+  // Compute material
+  const computeMaterial = useCallback(() => {
+    const values: Record<string, number> = { p: 1, n: 3, b: 3, r: 5, q: 9, k: 0 };
+    let w = 0;
+    let b = 0;
+    state.board.forEach(p => {
+      if (p) {
+        if (p.color === 'w') w += values[p.type];
+        else b += values[p.type];
+      }
+    });
+    return { whiteMaterial: w, blackMaterial: b };
+  }, [state.board]);
+
+  const { whiteMaterial, blackMaterial } = computeMaterial();
 
   return {
-    containerRef,
-    turn,
-    status,
+    state,
+    turn: state.turn,
+    status: state.status,
     playerWins,
     aiWins,
     draws,
     whiteMaterial,
     blackMaterial,
+    selectedSquare,
+    legalMoves,
+    promotionMove,
+    handleSquareClick,
+    handlePromotion,
+    resetGame,
+    cancelPromotion: () => setPromotionMove(null),
   };
 }


### PR DESCRIPTION
## Summary
This PR adds essential match control features to the chess game to resolve issue #226.

### Changes
- **Match Control (#226)**:
  - **Resign**: Players can now resign, awarding the win to the AI.
  - **Abort**: Games can be aborted without affecting the score if done during the first move.
  - **Offer Draw**: Players can offer a draw. The AI will accept if the material is roughly balanced.
- **State Management**:
  - Updated both the Phaser engine (`PlayScene`) and the React hook (`useGame`) to support these new end states.
  - Added new statuses: `resignation`, `draw_agreement`, `aborted`.
- **UI Updates**:
  - Added a control bar below the board with Resign, Draw, and Abort buttons.
  - Updated the HUD to show clear status labels for all new game end reasons.

## Verification
- Built both `@arcade/lib-chess` and `@arcade/web` successfully.
- Verified button visibility and logic for Resign, Abort, and Draw Offer.

Closes #226